### PR TITLE
Missing _lib/__init__.py

### DIFF
--- a/src/array_api_extra/_lib/_compat.pyi
+++ b/src/array_api_extra/_lib/_compat.pyi
@@ -2,6 +2,8 @@ from types import ModuleType
 
 from ._typing import Array, Device
 
+# pylint: disable=missing-class-docstring,unused-argument
+
 class ArrayModule(ModuleType):
     def device(self, x: Array, /) -> Device: ...
 


### PR DESCRIPTION
Fix crash in https://github.com/scipy/scipy/pull/22062
https://app.circleci.com/jobs/github/scipy/scipy/107558
```
Traceback:
/home/circleci/.pyenv/versions/3.11.11/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
scipy/_lib/array_api_extra/_lib/_utils.py:1: in <module>
    from . import _compat
E   ImportError: attempted relative import with no known parent package
=========================== short test summary info ============================
ERROR scipy/_lib/array_api_extra/_lib/_compat.py
ERROR scipy/_lib/array_api_extra/_lib/_typing.py
ERROR scipy/_lib/array_api_extra/_lib/_utils.py
!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 3 errors in 3.33s ===============================
```

I can't understand why this doesn't reproduce with the vendor_tests.
