### PR TITLE
ENH: add `pad`

### DIFF
--- a/src/array_api_extra/__init__.py
+++ b/src/array_api_extra/__init__.py
@@ -1,6 +1,6 @@
 """Extra array functions built on top of the array API standard."""
 
-from ._funcs import atleast_nd, cov, create_diagonal, expand_dims, kron, setdiff1d, sinc
+from ._funcs import atleast_nd, cov, create_diagonal, expand_dims, kron, setdiff1d, sinc, pad
 
 __version__ = "0.4.1.dev0"
 
@@ -14,4 +14,5 @@ __all__ = [
     "kron",
     "setdiff1d",
     "sinc",
+    "pad",
 ]

--- a/src/array_api_extra/__init__.py
+++ b/src/array_api_extra/__init__.py
@@ -1,6 +1,15 @@
 """Extra array functions built on top of the array API standard."""
 
-from ._funcs import atleast_nd, cov, create_diagonal, expand_dims, kron, setdiff1d, sinc, pad
+from ._funcs import (
+    atleast_nd,
+    cov,
+    create_diagonal,
+    expand_dims,
+    kron,
+    pad,
+    setdiff1d,
+    sinc,
+)
 
 __version__ = "0.4.1.dev0"
 
@@ -12,7 +21,7 @@ __all__ = [
     "create_diagonal",
     "expand_dims",
     "kron",
+    "pad",
     "setdiff1d",
     "sinc",
-    "pad",
 ]

--- a/src/array_api_extra/_funcs.py
+++ b/src/array_api_extra/_funcs.py
@@ -3,9 +3,7 @@
 import warnings
 
 from ._lib import _compat, _utils
-from ._lib._compat import (
-    array_namespace,
-)
+from ._lib._compat import array_namespace
 from ._lib._typing import Array, ModuleType
 
 __all__ = [
@@ -561,7 +559,8 @@ def pad(
     pad_width : int
         Pad the input array with this many elements from each side.
     mode : str, optional
-        Only "constant" mode is currently supported.
+        Only "constant" mode is currently supported, which pads with
+        the value passed to `constant_values`.
     xp : array_namespace, optional
         The standard-compatible namespace for `x`. Default: infer.
     constant_values : python scalar, optional
@@ -574,7 +573,8 @@ def pad(
         padded with ``pad_width`` elements equal to ``constant_values``.
     """
     if mode != "constant":
-        raise NotImplementedError()
+        msg = "Only `'constant'` mode is currently supported"
+        raise NotImplementedError(msg)
 
     value = constant_values
 

--- a/src/array_api_extra/_funcs.py
+++ b/src/array_api_extra/_funcs.py
@@ -582,7 +582,10 @@ def pad(
         xp = array_namespace(x)
 
     padded = xp.full(
-        tuple(x + 2 * pad_width for x in x.shape), fill_value=value, dtype=x.dtype
+        tuple(x + 2 * pad_width for x in x.shape),
+        fill_value=value,
+        dtype=x.dtype,
+        device=_compat.device(x),
     )
     padded[(slice(pad_width, -pad_width, None),) * x.ndim] = x
     return padded

--- a/src/array_api_extra/_lib/_compat.py
+++ b/src/array_api_extra/_lib/_compat.py
@@ -11,8 +11,6 @@ except ImportError:
     from array_api_compat import (  # pyright: ignore[reportMissingTypeStubs]
         array_namespace,  # pyright: ignore[reportUnknownVariableType]
         device,
-        is_torch_namespace,
-        is_array_api_strict_namespace,
     )
 
 __all__ = [

--- a/src/array_api_extra/_lib/_compat.py
+++ b/src/array_api_extra/_lib/_compat.py
@@ -11,6 +11,8 @@ except ImportError:
     from array_api_compat import (  # pyright: ignore[reportMissingTypeStubs]
         array_namespace,  # pyright: ignore[reportUnknownVariableType]
         device,
+        is_torch_namespace,
+        is_array_api_strict_namespace,
     )
 
 __all__ = [

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -403,3 +403,8 @@ class TestPad:
         a = xp.reshape(xp.arange(2 * 3 * 4), (2, 3, 4))
         padded = pad(a, 2)
         assert padded.shape == (6, 7, 8)
+
+    def test_mode_not_implemented(self):
+        a = xp.arange(3)
+        with pytest.raises(NotImplementedError, match="Only `'constant'`"):
+            pad(a, 2, mode="edge")

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -15,6 +15,7 @@ from array_api_extra import (
     kron,
     setdiff1d,
     sinc,
+    pad,
 )
 from array_api_extra._lib._typing import Array
 
@@ -385,3 +386,24 @@ class TestSinc:
 
     def test_xp(self):
         assert_array_equal(sinc(xp.asarray(0.0), xp=xp), xp.asarray(1.0))
+
+
+class TestPad:
+    def test_simple(self):
+        a = xp.arange(1, 4)
+        padded = pad(a, 2)
+        assert xp.all(padded == xp.asarray([0, 0, 1, 2, 3, 0, 0]))
+
+    def test_fill_value(self):
+        a = xp.arange(1, 4)
+        padded = pad(a, 2, constant_values=42)
+        assert xp.all(padded == xp.asarray([42, 42, 1, 2, 3, 42, 42]))
+
+    def test_ndim(self):
+        a = xp.reshape(xp.arange(2*3*4), (2, 3, 4))
+        padded = pad(a, 2)
+        assert padded.shape == (6, 7, 8)
+
+    def test_typo(self):
+        with pytest.raises(ValueError, match="Unknown"):
+            pad(xp.arange(2), pad_width=3, oops=3)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -408,3 +408,11 @@ class TestPad:
         a = xp.arange(3)
         with pytest.raises(NotImplementedError, match="Only `'constant'`"):
             pad(a, 2, mode="edge")
+
+    def test_device(self):
+        device = xp.Device("device1")
+        a = xp.asarray(0.0, device=device)
+        assert pad(a, 2).device == device
+
+    def test_xp(self):
+        assert_array_equal(pad(xp.asarray(0), 1, xp=xp), xp.zeros(3))

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -13,9 +13,9 @@ from array_api_extra import (
     create_diagonal,
     expand_dims,
     kron,
+    pad,
     setdiff1d,
     sinc,
-    pad,
 )
 from array_api_extra._lib._typing import Array
 
@@ -400,10 +400,6 @@ class TestPad:
         assert xp.all(padded == xp.asarray([42, 42, 1, 2, 3, 42, 42]))
 
     def test_ndim(self):
-        a = xp.reshape(xp.arange(2*3*4), (2, 3, 4))
+        a = xp.reshape(xp.arange(2 * 3 * 4), (2, 3, 4))
         padded = pad(a, 2)
         assert padded.shape == (6, 7, 8)
-
-    def test_typo(self):
-        with pytest.raises(ValueError, match="Unknown"):
-            pad(xp.arange(2), pad_width=3, oops=3)


### PR DESCRIPTION
closes gh-69

Add an `np.pad` replacement, as discussed at https://github.com/scipy/scipy/pull/22122/files#r1895558533