### PR TITLE
TYP: import annotations for sklearn

### DIFF
--- a/src/array_api_extra/_funcs.py
+++ b/src/array_api_extra/_funcs.py
@@ -1,5 +1,8 @@
 """Public API Functions."""
 
+# https://github.com/scikit-learn/scikit-learn/pull/27910#issuecomment-2568023972
+from __future__ import annotations
+
 import operator
 import warnings
 
@@ -719,7 +722,7 @@ class at:  # pylint: disable=invalid-name  # numpydoc ignore=PR02
         self._x = x
         self._idx = idx
 
-    def __getitem__(self, idx: Index, /) -> "at":  # numpydoc ignore=PR01,RT01
+    def __getitem__(self, idx: Index, /) -> at:  # numpydoc ignore=PR01,RT01
         """
         Allow for the alternate syntax ``at(x)[start:stop:step]``.
 

--- a/src/array_api_extra/_lib/_compat.pyi
+++ b/src/array_api_extra/_lib/_compat.pyi
@@ -1,5 +1,8 @@
 """Static type stubs for `_compat.py`."""
 
+# https://github.com/scikit-learn/scikit-learn/pull/27910#issuecomment-2568023972
+from __future__ import annotations
+
 from types import ModuleType
 
 from ._typing import Array, Device

--- a/src/array_api_extra/_lib/_utils.py
+++ b/src/array_api_extra/_lib/_utils.py
@@ -1,5 +1,8 @@
 """Utility functions used by `array_api_extra/_funcs.py`."""
 
+# https://github.com/scikit-learn/scikit-learn/pull/27910#issuecomment-2568023972
+from __future__ import annotations
+
 from . import _compat
 from ._typing import Array, ModuleType
 


### PR DESCRIPTION
sklearn has not dropped 3.9 yet... it probably isn't a great idea to "unofficially" support Python 3.9 like this, but if it works it works I guess 🤷‍♂️ hopefully scikit-learn will cotton on to SPEC0 at some point