### PR TITLE
ENH: `pad`: `pad_width` can be any sequence

### DIFF
--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -1,5 +1,6 @@
 """Delegation to existing implementations for Public API Functions."""
 
+from collections.abc import Sequence
 from types import ModuleType
 from typing import Literal
 
@@ -31,7 +32,7 @@ def _delegate(xp: ModuleType, *backends: Backend) -> bool:
 
 def pad(
     x: Array,
-    pad_width: int | tuple[int, int] | list[tuple[int, int]],
+    pad_width: int | tuple[int, int] | Sequence[tuple[int, int]],
     mode: Literal["constant"] = "constant",
     *,
     constant_values: bool | int | float | complex = 0,
@@ -44,9 +45,9 @@ def pad(
     ----------
     x : array
         Input array.
-    pad_width : int or tuple of ints or list of pairs of ints
+    pad_width : int or tuple of ints or sequence of pairs of ints
         Pad the input array with this many elements from each side.
-        If a list of tuples, ``[(before_0, after_0), ... (before_N, after_N)]``,
+        If a sequence of tuples, ``[(before_0, after_0), ... (before_N, after_N)]``,
         each pair applies to the corresponding axis of ``x``.
         A single tuple, ``(before, after)``, is equivalent to a list of ``x.ndim``
         copies of this tuple.

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -390,12 +390,12 @@ class TestPad:
         with pytest.raises((ValueError, RuntimeError)):
             pad(a, [(1, 2, 3)])  # type: ignore[list-item]  # pyright: ignore[reportArgumentType]
 
-    def test_list_of_tuples_width(self, xp: ModuleType):
+    def test_sequence_of_tuples_width(self, xp: ModuleType):
         a = xp.reshape(xp.arange(12), (3, 4))
-        padded = pad(a, [(1, 0), (0, 2)])
-        assert padded.shape == (4, 6)
 
-        padded = pad(a, [(1, 0), (0, 0)])
+        padded = pad(a, ((1, 0), (0, 2)))
+        assert padded.shape == (4, 6)
+        padded = pad(a, ((1, 0), (0, 0)))
         assert padded.shape == (4, 4)
 
 


### PR DESCRIPTION
This is a blocker to porting https://github.com/scipy/scipy/pull/22308 to xpx, because jax.jit doesn't accept unhashable static arguments.

For clarity: this is just a quirk of https://github.com/scipy/scipy/pull/22308. You *can* pass a list parameter to `xpx.pad` inside jax.jit; you simply can't pass it if you are calling `pad = jax.jit(xpx.pad, static_argnames="pad_width")`, which is not something final users will typically do.