### PR TITLE
ENH/TST: tougher restrictions on array_api_strict

### DIFF
--- a/src/array_api_extra/_lib/_at.py
+++ b/src/array_api_extra/_lib/_at.py
@@ -344,6 +344,7 @@ class at:  # pylint: disable=invalid-name  # numpydoc ignore=PR02
             msg = f"Can't update read-only array {x}"
             raise ValueError(msg)
 
+        # Backends without boolean indexing (other than JAX) crash here
         if in_place_op:  # add(), subtract(), ...
             x[idx] = in_place_op(x[idx], y)
         else:  # set()

--- a/src/array_api_extra/_lib/_backends.py
+++ b/src/array_api_extra/_lib/_backends.py
@@ -24,6 +24,7 @@ class Backend(Enum):  # numpydoc ignore=PR01,PR02  # type: ignore[no-subclass-an
     """
 
     ARRAY_API_STRICT = "array_api_strict", _compat.is_array_api_strict_namespace
+    ARRAY_API_STRICTEST = "array_api_strictest", _compat.is_array_api_strict_namespace
     NUMPY = "numpy", _compat.is_numpy_namespace
     NUMPY_READONLY = "numpy_readonly", _compat.is_numpy_namespace
     CUPY = "cupy", _compat.is_cupy_namespace

--- a/src/array_api_extra/_lib/_backends.py
+++ b/src/array_api_extra/_lib/_backends.py
@@ -1,9 +1,10 @@
 """Backends with which array-api-extra interacts in delegation and testing."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from enum import Enum
 from types import ModuleType
-from typing import cast
 
 from ._utils import _compat
 
@@ -23,10 +24,14 @@ class Backend(Enum):  # numpydoc ignore=PR01,PR02  # type: ignore[no-subclass-an
         corresponding to the backend.
     """
 
+    # Use :<tag> to prevent Enum from deduplicating items with the same value
     ARRAY_API_STRICT = "array_api_strict", _compat.is_array_api_strict_namespace
-    ARRAY_API_STRICTEST = "array_api_strictest", _compat.is_array_api_strict_namespace
+    ARRAY_API_STRICTEST = (
+        "array_api_strict:strictest",
+        _compat.is_array_api_strict_namespace,
+    )
     NUMPY = "numpy", _compat.is_numpy_namespace
-    NUMPY_READONLY = "numpy_readonly", _compat.is_numpy_namespace
+    NUMPY_READONLY = "numpy:readonly", _compat.is_numpy_namespace
     CUPY = "cupy", _compat.is_cupy_namespace
     TORCH = "torch", _compat.is_torch_namespace
     DASK = "dask.array", _compat.is_dask_namespace
@@ -49,4 +54,13 @@ class Backend(Enum):  # numpydoc ignore=PR01,PR02  # type: ignore[no-subclass-an
 
     def __str__(self) -> str:  # type: ignore[explicit-override]  # pyright: ignore[reportImplicitOverride]  # numpydoc ignore=RT01
         """Pretty-print parameterized test names."""
-        return cast(str, self.value)
+        return self.name.lower()
+
+    @property
+    def modname(self) -> str:  # numpydoc ignore=RT01
+        """Module name to be imported."""
+        return self.value.split(":")[0]
+
+    def like(self, *others: Backend) -> bool:  # numpydoc ignore=PR01,RT01
+        """Check if this backend uses the same module as others."""
+        return any(self.modname == other.modname for other in others)

--- a/src/array_api_extra/_lib/_utils/_helpers.py
+++ b/src/array_api_extra/_lib/_utils/_helpers.py
@@ -12,7 +12,9 @@ from ._compat import (
     array_namespace,
     is_array_api_obj,
     is_dask_namespace,
+    is_jax_namespace,
     is_numpy_array,
+    is_pydata_sparse_namespace,
 )
 from ._typing import Array
 
@@ -23,6 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 __all__ = [
     "asarrays",
+    "capabilities",
     "eager_shape",
     "in1d",
     "is_python_scalar",
@@ -270,3 +273,33 @@ def meta_namespace(
     # Quietly skip scalars and None's
     metas = [cast(Array | None, getattr(a, "_meta", None)) for a in arrays]
     return array_namespace(*metas)
+
+
+def capabilities(xp: ModuleType) -> dict[str, int]:
+    """
+    Return patched ``xp.__array_namespace_info__().capabilities()``.
+
+    Parameters
+    ----------
+    xp : array_namespace
+        The standard-compatible namespace.
+
+    Returns
+    -------
+    dict
+        Capabilities of the namespace.
+    """
+    if is_pydata_sparse_namespace(xp):
+        # No __array_namespace_info__(); no indexing by sparse arrays
+        return {"boolean indexing": False, "data-dependent shapes": True}
+    out = xp.__array_namespace_info__().capabilities()
+    if is_jax_namespace(xp):
+        # FIXME https://github.com/jax-ml/jax/issues/27418
+        out = out.copy()
+        out["boolean indexing"] = False
+    if is_dask_namespace(xp):
+        # FIXME https://github.com/data-apis/array-api-compat/pull/290
+        out = out.copy()
+        out["boolean indexing"] = True
+        out["data-dependent shapes"] = True
+    return out

--- a/src/array_api_extra/_lib/_utils/_helpers.py
+++ b/src/array_api_extra/_lib/_utils/_helpers.py
@@ -279,6 +279,9 @@ def capabilities(xp: ModuleType) -> dict[str, int]:
     """
     Return patched ``xp.__array_namespace_info__().capabilities()``.
 
+    TODO this helper should be eventually removed once all the special cases
+    it handles are fixed in the respective backends.
+
     Parameters
     ----------
     xp : array_namespace

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -20,7 +20,8 @@ from array_api_extra.testing import lazy_xp_function
 pytestmark = [
     pytest.mark.skip_xp_backend(
         Backend.SPARSE, reason="read-only backend without .at support"
-    )
+    ),
+    pytest.mark.skip_xp_backend(Backend.ARRAY_API_STRICTEST, reason="boolean indexing"),
 ]
 
 
@@ -256,7 +257,10 @@ def test_incompatible_dtype(
     elif library is Backend.DASK:
         z = at_op(x, idx, op, 1.1, copy=copy)
 
-    elif library is Backend.ARRAY_API_STRICT and op is not _AtOp.SET:
+    elif (
+        library in (Backend.ARRAY_API_STRICT, Backend.ARRAY_API_STRICTEST)
+        and op is not _AtOp.SET
+    ):
         with pytest.raises(Exception, match=r"cast|promote|dtype"):
             _ = at_op(x, idx, op, 1.1, copy=copy)
 

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -257,10 +257,7 @@ def test_incompatible_dtype(
     elif library is Backend.DASK:
         z = at_op(x, idx, op, 1.1, copy=copy)
 
-    elif (
-        library in (Backend.ARRAY_API_STRICT, Backend.ARRAY_API_STRICTEST)
-        and op is not _AtOp.SET
-    ):
+    elif library.like(Backend.ARRAY_API_STRICT) and op is not _AtOp.SET:
         with pytest.raises(Exception, match=r"cast|promote|dtype"):
             _ = at_op(x, idx, op, 1.1, copy=copy)
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -838,9 +838,7 @@ class TestNUnique:
         xp_assert_equal(nunique(a), xp.asarray(1))
 
     @pytest.mark.xfail_xp_backend(Backend.DASK, reason="No equal_nan kwarg in unique")
-    @pytest.mark.xfail_xp_backend(
-        Backend.SPARSE, reason="Non-compliant equal_nan=True behaviour"
-    )
+    @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="sparse#855")
     def test_nan(self, xp: ModuleType, library: Backend):
         if library.like(Backend.NUMPY) and NUMPY_VERSION < (1, 24):
             pytest.xfail("NumPy <1.24 has no equal_nan kwarg in unique")

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -223,7 +223,7 @@ def test_lazy_xp_function_cython_ufuncs(xp: ModuleType, library: Backend):
     pytest.importorskip("scipy")
     assert erf is not None
     x = xp.asarray([6.0, 7.0])
-    if library in (Backend.ARRAY_API_STRICT, Backend.ARRAY_API_STRICTEST, Backend.JAX):
+    if library.like(Backend.ARRAY_API_STRICT, Backend.JAX):
         # array-api-strict arrays are auto-converted to NumPy
         # which results in an assertion error for mismatched namespaces
         # eager JAX arrays are auto-converted to NumPy in eager JAX

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -72,7 +72,8 @@ def test_assert_close_tolerance(xp: ModuleType):
 
 
 @param_assert_equal_close
-@pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="index by sparse array")
+@pytest.mark.skip_xp_backend(Backend.SPARSE, reason="index by sparse array")
+@pytest.mark.skip_xp_backend(Backend.ARRAY_API_STRICTEST, reason="boolean indexing")
 def test_assert_close_equal_none_shape(xp: ModuleType, func: Callable[..., None]):  # type: ignore[explicit-any]
     """On Dask and other lazy backends, test that a shape with NaN's or None's
     can be compared to a real shape.
@@ -222,7 +223,7 @@ def test_lazy_xp_function_cython_ufuncs(xp: ModuleType, library: Backend):
     pytest.importorskip("scipy")
     assert erf is not None
     x = xp.asarray([6.0, 7.0])
-    if library in (Backend.ARRAY_API_STRICT, Backend.JAX):
+    if library in (Backend.ARRAY_API_STRICT, Backend.ARRAY_API_STRICTEST, Backend.JAX):
         # array-api-strict arrays are auto-converted to NumPy
         # which results in an assertion error for mismatched namespaces
         # eager JAX arrays are auto-converted to NumPy in eager JAX


### PR DESCRIPTION
- Run all tests with array-api-strict with all optional capabilities disabled
- Add `nunique` support for unknown backends without `unique_counts` - for example, `marray` wrapping around JAX.
- Add `apply_where` support for unknown backends without boolean index assignment - again for example `marray` wrapping around JAX (but see https://github.com/jax-ml/jax/issues/27418) 
- Add `apply_where` support for sparse arrays

# Upstream issues
- https://github.com/jax-ml/jax/issues/27418
- https://github.com/data-apis/array-api-compat/pull/290
- https://github.com/mdhaber/marray/issues/99