### PR TITLE
Add expit function

### DIFF
--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -913,3 +913,29 @@ def sinc(x: Array, /, *, xp: ModuleType | None = None) -> Array:
         xp.asarray(xp.finfo(x.dtype).eps, dtype=x.dtype, device=_compat.device(x)),
     )
     return xp.sin(y) / y
+
+
+def expit(x: Array, /, *, xp: ModuleType | None = None) -> Array:
+    """
+    Return the expit function.
+
+    The expit function, also known as the logistic sigmoid function.
+    It is the inverse of the logit function.
+
+    Parameters
+    ----------
+    x : array
+        Input array.
+    xp : array_namespace, optional
+        The standard-compatible namespace for `x`. Default: infer.
+
+    Returns
+    -------
+    array
+        An array of the same shape as x. Its entries are expit of the
+        corresponding entry of x.
+    """
+    if xp is None:
+        xp = array_namespace(x)
+
+    return 1.0 / (1.0 + xp.exp(-x))

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+from scipy import special
 
 from array_api_extra import (
     apply_where,
@@ -26,6 +27,7 @@ from array_api_extra import (
     sinc,
 )
 from array_api_extra._lib import Backend
+from array_api_extra._lib._funcs import expit
 from array_api_extra._lib._testing import xp_assert_close, xp_assert_equal
 from array_api_extra._lib._utils._compat import device as get_device
 from array_api_extra._lib._utils._helpers import eager_shape, ndindex
@@ -1003,3 +1005,12 @@ class TestSinc:
 
     def test_xp(self, xp: ModuleType):
         xp_assert_equal(sinc(xp.asarray(0.0), xp=xp), xp.asarray(1.0))
+
+
+class TestExpit:
+    def test_simple(self, xp: ModuleType):
+        x = xp.asarray([2, 3, 4, 5])
+        np_x = np.asarray([2, 3, 4, 5])
+        actual = expit(x)
+        expected = special.expit(np_x)
+        xp_assert_close(actual, expected)


### PR DESCRIPTION
CC: @lucascolley 

I started with adding this simple function although I am not sure whether we need to add it at all. However does the format look fine. I think we might need more tests that test for dtypes and devices.

Also I am not sure how do I set this up locally to run tests. Do I need to install it? I was simply trying to configure the tests in Visual Studio code on a windows machine but it gives the following error:

```
from array_api_extra._lib import Backend
E   ModuleNotFoundError: No module named 'array_api_extra'
```