### PR TITLE
TST: run tests on CPU+GPU

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5232,7 +5232,7 @@ packages:
 - pypi: .
   name: array-api-extra
   version: 0.7.2.dev0
-  sha256: be7523c2bc2519d23eb7e92abc0466bbb70d37728f0b677e5acfd67350a2e212
+  sha256: a8d2952c22c94bd9fb24d5d293222f859bc9b6c255361ad4d25380f6099dcd45
   requires_dist:
   - array-api-compat>=1.11.2,<2
   requires_python: '>=3.10'

--- a/pixi.lock
+++ b/pixi.lock
@@ -5256,7 +5256,7 @@ packages:
 - pypi: .
   name: array-api-extra
   version: 0.7.2.dev0
-  sha256: 038ce201a10c2f3747ee69453356a561627455e1caa462151433eaeea9bdcea6
+  sha256: a46c6db2ae9462de7b2b2078ea507a1bd7e21f2a6170bfed292f306878055331
   requires_dist:
   - array-api-compat>=1.11.2,<2
   requires_python: '>=3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,7 +238,7 @@ disable_error_code = ["redundant-expr", "unreachable", "no-any-return"]
 
 [[tool.mypy.overrides]]
 # slow/unavailable on Windows; do not add to the lint env
-module = ["dask.*", "jax.*"]
+module = ["dask.*", "jax.*", "torch.*"]
 ignore_missing_imports = true
 
 # pyright

--- a/src/array_api_extra/_lib/_at.py
+++ b/src/array_api_extra/_lib/_at.py
@@ -8,10 +8,12 @@ from enum import Enum
 from types import ModuleType
 from typing import TYPE_CHECKING, ClassVar, cast
 
+from ._utils import _compat
 from ._utils._compat import (
     array_namespace,
     is_dask_array,
     is_jax_array,
+    is_torch_array,
     is_writeable_array,
 )
 from ._utils._helpers import meta_namespace
@@ -298,7 +300,7 @@ class at:  # pylint: disable=invalid-name  # numpydoc ignore=PR02
             and idx.dtype == xp.bool
             and idx.shape == x.shape
         ):
-            y_xp = xp.asarray(y, dtype=x.dtype)
+            y_xp = xp.asarray(y, dtype=x.dtype, device=_compat.device(x))
             if y_xp.ndim == 0:
                 if out_of_place_op:  # add(), subtract(), ...
                     # suppress inf warnings on Dask
@@ -343,6 +345,12 @@ class at:  # pylint: disable=invalid-name  # numpydoc ignore=PR02
             # sparse crashes here
             msg = f"Can't update read-only array {x}"
             raise ValueError(msg)
+
+        # Work around bug in PyTorch where __setitem__ doesn't
+        # always support mismatched dtypes
+        # https://github.com/pytorch/pytorch/issues/150017
+        if is_torch_array(y):
+            y = xp.astype(y, x.dtype, copy=False)
 
         # Backends without boolean indexing (other than JAX) crash here
         if in_place_op:  # add(), subtract(), ...

--- a/src/array_api_extra/_lib/_backends.py
+++ b/src/array_api_extra/_lib/_backends.py
@@ -34,9 +34,11 @@ class Backend(Enum):  # numpydoc ignore=PR01,PR02  # type: ignore[no-subclass-an
     NUMPY_READONLY = "numpy:readonly", _compat.is_numpy_namespace
     CUPY = "cupy", _compat.is_cupy_namespace
     TORCH = "torch", _compat.is_torch_namespace
+    TORCH_GPU = "torch:gpu", _compat.is_torch_namespace
     DASK = "dask.array", _compat.is_dask_namespace
     SPARSE = "sparse", _compat.is_pydata_sparse_namespace
     JAX = "jax.numpy", _compat.is_jax_namespace
+    JAX_GPU = "jax.numpy:gpu", _compat.is_jax_namespace
 
     def __new__(
         cls, value: str, _is_namespace: Callable[[ModuleType], bool]
@@ -54,7 +56,9 @@ class Backend(Enum):  # numpydoc ignore=PR01,PR02  # type: ignore[no-subclass-an
 
     def __str__(self) -> str:  # type: ignore[explicit-override]  # pyright: ignore[reportImplicitOverride]  # numpydoc ignore=RT01
         """Pretty-print parameterized test names."""
-        return self.name.lower()
+        return (
+            self.name.lower().replace("_gpu", ":gpu").replace("_readonly", ":readonly")
+        )
 
     @property
     def modname(self) -> str:  # numpydoc ignore=RT01

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ def xp(
             try:
                 device = jax.devices("cuda")[0]
             except RuntimeError:
-                pytest.skip("no cuda device available")
+                pytest.skip("no CUDA device available")
         else:
             device = jax.devices("cpu")[0]
         jax.config.update("jax_default_device", device)
@@ -158,7 +158,7 @@ def xp(
         import torch.cuda
 
         if not torch.cuda.is_available():
-            pytest.skip("no cuda device available")
+            pytest.skip("no CUDA device available")
         xp.set_default_device("cuda")
 
     elif library == Backend.TORCH:  # CPU

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -118,6 +118,9 @@ def assert_copy(
                 pytest.mark.skip_xp_backend(  # test passes when copy=False
                     Backend.JAX, reason="bool mask update with shaped rhs"
                 ),
+                pytest.mark.skip_xp_backend(  # test passes when copy=False
+                    Backend.JAX_GPU, reason="bool mask update with shaped rhs"
+                ),
                 pytest.mark.xfail_xp_backend(
                     Backend.DASK, reason="bool mask update with shaped rhs"
                 ),
@@ -247,14 +250,14 @@ def test_incompatible_dtype(
     idx = xp.asarray([True, False]) if bool_mask else slice(None)
     z = None
 
-    if library is Backend.JAX:
+    if library.like(Backend.JAX):
         if bool_mask:
             z = at_op(x, idx, op, 1.1, copy=copy)
         else:
             with pytest.warns(FutureWarning, match="cannot safely cast"):
                 z = at_op(x, idx, op, 1.1, copy=copy)
 
-    elif library is Backend.DASK:
+    elif library.like(Backend.DASK):
         z = at_op(x, idx, op, 1.1, copy=copy)
 
     elif library.like(Backend.ARRAY_API_STRICT) and op is not _AtOp.SET:
@@ -302,6 +305,9 @@ def test_no_inf_warnings(xp: ModuleType, bool_mask: bool):
                     Backend.NUMPY_READONLY, reason="read-only backend"
                 ),
                 pytest.mark.skip_xp_backend(Backend.JAX, reason="read-only backend"),
+                pytest.mark.skip_xp_backend(
+                    Backend.JAX_GPU, reason="read-only backend"
+                ),
                 pytest.mark.skip_xp_backend(Backend.SPARSE, reason="read-only backend"),
             ],
         ),

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -234,7 +234,7 @@ class TestApplyWhere:
 
         # cupy/cupy#8382
         # https://github.com/jax-ml/jax/issues/26658
-        elements = {"allow_subnormal": library not in (Backend.CUPY, Backend.JAX)}
+        elements = {"allow_subnormal": not library.like(Backend.CUPY, Backend.JAX)}
 
         fill_value = xp.asarray(
             data.draw(npst.arrays(dtype=dtype, shape=(), elements=elements))
@@ -929,6 +929,9 @@ class TestSetDiff1D:
     @pytest.mark.xfail_xp_backend(Backend.DASK, reason="NaN-shaped arrays")
     @pytest.mark.xfail_xp_backend(
         Backend.TORCH, reason="index_select not implemented for uint32"
+    )
+    @pytest.mark.xfail_xp_backend(
+        Backend.TORCH_GPU, reason="index_select not implemented for uint32"
     )
     def test_setdiff1d(self, xp: ModuleType):
         x1 = xp.asarray([6, 5, 4, 7, 1, 2, 7, 4])

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -27,6 +27,9 @@ as_numpy = pytest.mark.parametrize(
             True,
             marks=[
                 pytest.mark.skip_xp_backend(Backend.CUPY, reason="device->host copy"),
+                pytest.mark.skip_xp_backend(
+                    Backend.TORCH_GPU, reason="device->host copy"
+                ),
                 pytest.mark.skip_xp_backend(Backend.SPARSE, reason="densification"),
             ],
         ),
@@ -100,6 +103,9 @@ def test_lazy_apply_multi_output(xp: ModuleType, as_numpy: bool):
             True,
             marks=[
                 pytest.mark.skip_xp_backend(Backend.CUPY, reason="device->host copy"),
+                pytest.mark.skip_xp_backend(
+                    Backend.TORCH_GPU, reason="device->host copy"
+                ),
                 pytest.mark.skip_xp_backend(Backend.SPARSE, reason="densification"),
             ],
         ),
@@ -216,7 +222,7 @@ def test_lazy_apply_none_shape_in_args(xp: ModuleType, library: Backend):
     int_type = xp.asarray(0).dtype
 
     ctx: contextlib.AbstractContextManager[object]
-    if library is Backend.JAX:
+    if library.like(Backend.JAX):
         ctx = pytest.raises(ValueError, match="Output shape must be fully known")
     elif library is Backend.ARRAY_API_STRICTEST:
         ctx = pytest.raises(RuntimeError, match="data-dependent shapes")
@@ -254,6 +260,7 @@ lazy_xp_function(check_lazy_apply_none_shape_broadcast)
 
 @pytest.mark.skip_xp_backend(Backend.SPARSE, reason="index by sparse array")
 @pytest.mark.skip_xp_backend(Backend.JAX, reason="boolean indexing")
+@pytest.mark.skip_xp_backend(Backend.JAX_GPU, reason="boolean indexing")
 @pytest.mark.skip_xp_backend(Backend.ARRAY_API_STRICTEST, reason="boolean indexing")
 def test_lazy_apply_none_shape_broadcast(xp: ModuleType):
     """Broadcast from input array with unknown shape"""
@@ -273,6 +280,9 @@ def test_lazy_apply_none_shape_broadcast(xp: ModuleType):
                     Backend.ARRAY_API_STRICT, reason="device->host copy"
                 ),
                 pytest.mark.skip_xp_backend(Backend.CUPY, reason="device->host copy"),
+                pytest.mark.skip_xp_backend(
+                    Backend.TORCH_GPU, reason="device->host copy"
+                ),
                 pytest.mark.skip_xp_backend(Backend.SPARSE, reason="densification"),
             ],
         ),
@@ -321,7 +331,7 @@ def test_lazy_apply_scalars_and_nones(xp: ModuleType, library: Backend):
         assert isinstance(x, mtyp)
         assert y is None
         # jax.pure_callback wraps scalar args
-        assert isinstance(z, mtyp if library is Backend.JAX else int)
+        assert isinstance(z, mtyp if library.like(Backend.JAX) else int)
         return x + z
 
     x = xp.asarray([1, 2])

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -218,6 +218,7 @@ except ImportError:
     erf = None
 
 
+@pytest.mark.skip_xp_backend(Backend.TORCH_GPU, reason="device->host copy")
 @pytest.mark.filterwarnings("ignore:__array_wrap__:DeprecationWarning")  # PyTorch
 def test_lazy_xp_function_cython_ufuncs(xp: ModuleType, library: Backend):
     pytest.importorskip("scipy")
@@ -293,12 +294,12 @@ def test_lazy_xp_modules(xp: ModuleType, library: Backend):
     y = naked.f(x)
     xp_assert_equal(y, x)
 
-    if library is Backend.JAX:
+    if library.like(Backend.JAX):
         with pytest.raises(
             TypeError, match="Attempted boolean conversion of traced array"
         ):
             wrapped.f(x)
-    elif library is Backend.DASK:
+    elif library.like(Backend.DASK):
         with pytest.raises(AssertionError, match=r"dask\.compute"):
             wrapped.f(x)
     else:


### PR DESCRIPTION
- On the `tests-cuda` and `dev-cuda` pixi environments, run all tests first on CPU and then on GPU:
  - on JAX (before it was only on GPU)
  - on PyTorch (before it was only on CPU)
- Work around PyTorch bug impacting `xpx.at` https://github.com/pytorch/pytorch/issues/150017