### PR TITLE
MAINT: Don't use `Backend` for delegation

### DIFF
--- a/src/array_api_extra/_lib/__init__.py
+++ b/src/array_api_extra/_lib/__init__.py
@@ -1,5 +1,1 @@
 """Internals of array-api-extra."""
-
-from ._backends import Backend
-
-__all__ = ["Backend"]

--- a/src/array_api_extra/_lib/_backends.py
+++ b/src/array_api_extra/_lib/_backends.py
@@ -1,58 +1,34 @@
-"""Backends with which array-api-extra interacts in delegation and testing."""
+"""Backends with which array-api-extra runs its tests against."""
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from enum import Enum
-from types import ModuleType
-
-from ._utils import _compat
 
 __all__ = ["Backend"]
 
 
-class Backend(Enum):  # numpydoc ignore=PR01,PR02  # type: ignore[no-subclass-any]
+class Backend(Enum):  # numpydoc ignore=PR02
     """
     All array library backends explicitly tested by array-api-extra.
 
     Parameters
     ----------
     value : str
-        Name of the backend's module.
-    is_namespace : Callable[[ModuleType], bool]
-        Function to check whether an input module is the array namespace
-        corresponding to the backend.
+        Tag of the backend's module, in the format ``<namespace>[:<extra tag>]``.
     """
 
     # Use :<tag> to prevent Enum from deduplicating items with the same value
-    ARRAY_API_STRICT = "array_api_strict", _compat.is_array_api_strict_namespace
-    ARRAY_API_STRICTEST = (
-        "array_api_strict:strictest",
-        _compat.is_array_api_strict_namespace,
-    )
-    NUMPY = "numpy", _compat.is_numpy_namespace
-    NUMPY_READONLY = "numpy:readonly", _compat.is_numpy_namespace
-    CUPY = "cupy", _compat.is_cupy_namespace
-    TORCH = "torch", _compat.is_torch_namespace
-    TORCH_GPU = "torch:gpu", _compat.is_torch_namespace
-    DASK = "dask.array", _compat.is_dask_namespace
-    SPARSE = "sparse", _compat.is_pydata_sparse_namespace
-    JAX = "jax.numpy", _compat.is_jax_namespace
-    JAX_GPU = "jax.numpy:gpu", _compat.is_jax_namespace
-
-    def __new__(
-        cls, value: str, _is_namespace: Callable[[ModuleType], bool]
-    ):  # numpydoc ignore=GL08
-        obj = object.__new__(cls)
-        obj._value_ = value
-        return obj
-
-    def __init__(
-        self,
-        value: str,  # noqa: ARG002  # pylint: disable=unused-argument
-        is_namespace: Callable[[ModuleType], bool],
-    ):  # numpydoc ignore=GL08
-        self.is_namespace = is_namespace
+    ARRAY_API_STRICT = "array_api_strict"
+    ARRAY_API_STRICTEST = "array_api_strict:strictest"
+    NUMPY = "numpy"
+    NUMPY_READONLY = "numpy:readonly"
+    CUPY = "cupy"
+    TORCH = "torch"
+    TORCH_GPU = "torch:gpu"
+    DASK = "dask.array"
+    SPARSE = "sparse"
+    JAX = "jax.numpy"
+    JAX_GPU = "jax.numpy:gpu"
 
     def __str__(self) -> str:  # type: ignore[explicit-override]  # pyright: ignore[reportImplicitOverride]  # numpydoc ignore=RT01
         """Pretty-print parameterized test names."""

--- a/src/array_api_extra/_lib/_backends.py
+++ b/src/array_api_extra/_lib/_backends.py
@@ -1,4 +1,4 @@
-"""Backends with which array-api-extra runs its tests against."""
+"""Backends against which array-api-extra runs its tests."""
 
 from __future__ import annotations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from typing import ParamSpec, TypeVar, cast
 import numpy as np
 import pytest
 
-from array_api_extra._lib import Backend
+from array_api_extra._lib._backends import Backend
 from array_api_extra._lib._testing import xfail
 from array_api_extra._lib._utils._compat import array_namespace
 from array_api_extra._lib._utils._compat import device as get_device

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -9,8 +9,8 @@ import numpy as np
 import pytest
 
 from array_api_extra import at
-from array_api_extra._lib import Backend
 from array_api_extra._lib._at import _AtOp
+from array_api_extra._lib._backends import Backend
 from array_api_extra._lib._testing import xp_assert_equal
 from array_api_extra._lib._utils._compat import array_namespace, is_writeable_array
 from array_api_extra._lib._utils._compat import device as get_device

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -25,7 +25,7 @@ from array_api_extra import (
     setdiff1d,
     sinc,
 )
-from array_api_extra._lib import Backend
+from array_api_extra._lib._backends import Backend
 from array_api_extra._lib._testing import xp_assert_close, xp_assert_equal
 from array_api_extra._lib._utils._compat import device as get_device
 from array_api_extra._lib._utils._helpers import eager_shape, ndindex

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,7 +4,7 @@ from typing import cast
 import numpy as np
 import pytest
 
-from array_api_extra._lib import Backend
+from array_api_extra._lib._backends import Backend
 from array_api_extra._lib._testing import xp_assert_equal
 from array_api_extra._lib._utils._compat import array_namespace
 from array_api_extra._lib._utils._compat import device as get_device

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -7,7 +7,7 @@ import pytest
 
 import array_api_extra as xpx  # Let some tests bypass lazy_xp_function
 from array_api_extra import lazy_apply
-from array_api_extra._lib import Backend
+from array_api_extra._lib._backends import Backend
 from array_api_extra._lib._testing import xp_assert_equal
 from array_api_extra._lib._utils import _compat
 from array_api_extra._lib._utils._compat import array_namespace, is_dask_array

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -5,7 +5,7 @@ from typing import cast
 import numpy as np
 import pytest
 
-from array_api_extra._lib import Backend
+from array_api_extra._lib._backends import Backend
 from array_api_extra._lib._testing import xp_assert_close, xp_assert_equal
 from array_api_extra._lib._utils._compat import (
     array_namespace,


### PR DESCRIPTION
Follow-up from https://github.com/data-apis/array-api-extra/pull/221#discussion_r2033668108

Do not use the `Backend` enum outside of testing.

This enum contains a lot of "backends" that are just variant duplicates, which is an artifact of using this enum to parametrize the `xp` fixture. Which is a decent hack for pytest, but which doesn't make any sense in the context of the dispatch system.

This also allows for quite a bit of simplification without adding any weight to the delegate module itself.