### PR TITLE
TST: `xfail_xp_backend(strict=False)`

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5256,7 +5256,7 @@ packages:
 - pypi: .
   name: array-api-extra
   version: 0.7.2.dev0
-  sha256: 74777bddfe6ab8d3ced9e5d1c645cb95c637707a45de9e96c88fc3b41723e3af
+  sha256: 68490b5f2feb7687422f882f54bb2a93c687425b984a69ecd58c9d6d73653139
   requires_dist:
   - array-api-compat>=1.11.2,<2
   requires_python: '>=3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,8 +213,8 @@ filterwarnings = ["error"]
 log_cli_level = "INFO"
 testpaths = ["tests"]
 markers = [
-  "skip_xp_backend(library, *, reason=None): Skip test for a specific backend",
-  "xfail_xp_backend(library, *, reason=None): Xfail test for a specific backend",
+  "skip_xp_backend(library, /, *, reason=None): Skip test for a specific backend",
+  "xfail_xp_backend(library, /, *, reason=None, strict=None): Xfail test for a specific backend",
 ]
 
 

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -195,7 +195,9 @@ def xp_assert_close(
         )
 
 
-def xfail(request: pytest.FixtureRequest, reason: str) -> None:
+def xfail(
+    request: pytest.FixtureRequest, *, reason: str, strict: bool | None = None
+) -> None:
     """
     XFAIL the currently running test.
 
@@ -209,5 +211,13 @@ def xfail(request: pytest.FixtureRequest, reason: str) -> None:
         ``request`` argument of the test function.
     reason : str
         Reason for the expected failure.
+    strict: bool, optional
+        If True, the test will be marked as failed if it passes.
+        If False, the test will be marked as passed if it fails.
+        Default: ``xfail_strict`` value in ``pyproject.toml``, or False if absent.
     """
-    request.node.add_marker(pytest.mark.xfail(reason=reason))
+    if strict is not None:
+        marker = pytest.mark.xfail(reason=reason, strict=strict)
+    else:
+        marker = pytest.mark.xfail(reason=reason)
+    request.node.add_marker(marker)

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -115,11 +115,15 @@ def assert_copy(
         pytest.param(
             *(True, 1, 1),
             marks=(
-                pytest.mark.skip_xp_backend(  # test passes when copy=False
-                    Backend.JAX, reason="bool mask update with shaped rhs"
+                pytest.mark.xfail_xp_backend(
+                    Backend.JAX,
+                    reason="bool mask update with shaped rhs",
+                    strict=False,  # test passes when copy=False
                 ),
-                pytest.mark.skip_xp_backend(  # test passes when copy=False
-                    Backend.JAX_GPU, reason="bool mask update with shaped rhs"
+                pytest.mark.xfail_xp_backend(
+                    Backend.JAX_GPU,
+                    reason="bool mask update with shaped rhs",
+                    strict=False,  # test passes when copy=False
                 ),
                 pytest.mark.xfail_xp_backend(
                     Backend.DASK, reason="bool mask update with shaped rhs"

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -196,7 +196,7 @@ class TestApplyWhere:
         y = apply_where(x % 2 == 0, x, self.f1, fill_value=x)
         assert get_device(y) == device
 
-    @pytest.mark.skip_xp_backend(Backend.SPARSE, reason="no isdtype")
+    @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no isdtype")
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")  # overflows, etc.
     @hypothesis.settings(
         # The xp and library fixtures are not regenerated between hypothesis iterations

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -27,7 +27,7 @@ from .conftest import np_compat
 lazy_xp_function(in1d, jax_jit=False, static_argnames=("assume_unique", "invert", "xp"))
 
 
-@pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no unique_inverse")
+@pytest.mark.skip_xp_backend(Backend.SPARSE, reason="no unique_inverse")
 @pytest.mark.skip_xp_backend(Backend.ARRAY_API_STRICTEST, reason="no unique_inverse")
 class TestIn1D:
     # cover both code paths


### PR DESCRIPTION
- Add `strict=False` optional parameter to `xfail_xp_backend`
- raise on spurious kwargs