### PR TITLE
TST: flaky `test_single_axis` on Dask

### DIFF
--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -521,7 +521,7 @@ class TestCreateDiagonal:
 class TestExpandDims:
     def test_single_axis(self, xp: ModuleType):
         """Trivial case where xpx.expand_dims doesn't add anything to xp.expand_dims"""
-        a = xp.empty((2, 3, 4, 5))
+        a = xp.asarray(np.reshape(np.arange(2 * 3 * 4 * 5), (2, 3, 4, 5)))
         for axis in range(-5, 4):
             b = expand_dims(a, axis=axis)
             xp_assert_equal(b, xp.expand_dims(a, axis=axis))


### PR DESCRIPTION
I'm observing random failures in Dask in this test.
The reason is that `xp_assert_equal()` is calling `dask.compute()` twice, which in turn rematerializes the graph from scratch twice - thus calling `np.empty` twice. That in turn occasionally returns differently dirty memory between `expect` and `actual`.