### PR TITLE
DEV: disable codecov project status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,6 @@ github_checks:
 ignore:
   - "src/array_api_extra/_lib/_compat"
   - "src/array_api_extra/_lib/_typing"
+coverage:
+  status:
+    project: off


### PR DESCRIPTION
this avoids failing statuses on PRs due to having to wait for test-backends in unrelated areas of the codebase