### PR TITLE
ENH: support PyTorch `device='meta'`

### DIFF
--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -153,7 +153,7 @@ def _apply_where(  # type: ignore[explicit-any]  # numpydoc ignore=PR01,RT01
 ) -> Array:
     """Helper of `apply_where`. On Dask, this runs on a single chunk."""
 
-    if not capabilities(xp)["boolean indexing"]:
+    if not capabilities(xp, device=_compat.device(cond))["boolean indexing"]:
         # jax.jit does not support assignment by boolean mask
         return xp.where(cond, f1(*args), f2(*args) if f2 is not None else fill_value)
 
@@ -716,7 +716,7 @@ def nunique(x: Array, /, *, xp: ModuleType | None = None) -> Array:
     # 2. backend has unique_counts and it returns a None-sized array;
     #    e.g. Dask, ndonnx
     # 3. backend does not have unique_counts; e.g. wrapped JAX
-    if capabilities(xp)["data-dependent shapes"]:
+    if capabilities(xp, device=_compat.device(x))["data-dependent shapes"]:
         # xp has unique_counts; O(n) complexity
         _, counts = xp.unique_counts(x)
         n = _compat.size(counts)

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -100,7 +100,11 @@ def as_numpy_array(array: Array, *, xp: ModuleType) -> np.typing.NDArray[Any]:  
         return array.todense()  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
 
     if is_torch_namespace(xp):
-        array = to_device(array, "cpu")
+        if array.device.type == "meta":  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
+            # Can't materialize; generate dummy data instead
+            array = xp.zeros_like(array, device="cpu")
+        else:
+            array = to_device(array, "cpu")
     if is_array_api_strict_namespace(xp):
         cpu: Device = xp.Device("CPU_DEVICE")
         array = to_device(array, cpu)

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -103,9 +103,7 @@ def _check_ns_shape_dtype(
 
 def _is_materializable(x: Array) -> bool:
     """
-    Check if the array is materializable, e.g. `as_numpy_array` can be called on it
-    and one can assume that `__dlpack__` will succeed (if implemented, and given a
-    compatible device).
+    Return True if you can call `as_numpy_array(x)`; False otherwise.
     """
     # Important: here we assume that we're not tracing -
     # e.g. we're not inside `jax.jit`` nor `cupy.cuda.Stream.begin_capture`.

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -22,6 +22,7 @@ from ._utils._compat import (
     is_jax_namespace,
     is_numpy_namespace,
     is_pydata_sparse_namespace,
+    is_torch_array,
     is_torch_namespace,
     to_device,
 )
@@ -62,18 +63,28 @@ def _check_ns_shape_dtype(
     msg = f"namespaces do not match: {actual_xp} != f{desired_xp}"
     assert actual_xp == desired_xp, msg
 
-    if check_shape:
-        actual_shape = actual.shape
-        desired_shape = desired.shape
-        if is_dask_namespace(desired_xp):
-            # Dask uses nan instead of None for unknown shapes
-            if any(math.isnan(i) for i in cast(tuple[float, ...], actual_shape)):
-                actual_shape = actual.compute().shape  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
-            if any(math.isnan(i) for i in cast(tuple[float, ...], desired_shape)):
-                desired_shape = desired.compute().shape  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
+    # Dask uses nan instead of None for unknown shapes
+    actual_shape = cast(tuple[float, ...], actual.shape)
+    desired_shape = cast(tuple[float, ...], desired.shape)
+    assert None not in actual_shape  # Requires explicit support
+    assert None not in desired_shape
+    if is_dask_namespace(desired_xp):
+        if any(math.isnan(i) for i in actual_shape):
+            actual_shape = actual.compute().shape  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
+        if any(math.isnan(i) for i in desired_shape):
+            desired_shape = desired.compute().shape  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
 
+    if check_shape:
         msg = f"shapes do not match: {actual_shape} != f{desired_shape}"
         assert actual_shape == desired_shape, msg
+    else:
+        # Ignore shape, but check flattened size. This is normally done by
+        # np.testing.assert_array_equal etc even when strict=False, but not for
+        # non-materializable arrays.
+        actual_size = math.prod(actual_shape)  # pyright: ignore[reportUnknownArgumentType]
+        desired_size = math.prod(desired_shape)  # pyright: ignore[reportUnknownArgumentType]
+        msg = f"sizes do not match: {actual_size} != f{desired_size}"
+        assert actual_size == desired_size, msg
 
     if check_dtype:
         msg = f"dtypes do not match: {actual.dtype} != {desired.dtype}"
@@ -90,6 +101,17 @@ def _check_ns_shape_dtype(
     return desired_xp
 
 
+def _is_materializable(x: Array) -> bool:
+    """
+    Check if the array is materializable, e.g. `as_numpy_array` can be called on it
+    and one can assume that `__dlpack__` will succeed (if implemented, and given a
+    compatible device).
+    """
+    # Important: here we assume that we're not tracing -
+    # e.g. we're not inside `jax.jit`` nor `cupy.cuda.Stream.begin_capture`.
+    return not is_torch_array(x) or x.device.type != "meta"  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
+
+
 def as_numpy_array(array: Array, *, xp: ModuleType) -> np.typing.NDArray[Any]:  # type: ignore[explicit-any]
     """
     Convert array to NumPy, bypassing GPU-CPU transfer guards and densification guards.
@@ -100,11 +122,7 @@ def as_numpy_array(array: Array, *, xp: ModuleType) -> np.typing.NDArray[Any]:  
         return array.todense()  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
 
     if is_torch_namespace(xp):
-        if array.device.type == "meta":  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
-            # Can't materialize; generate dummy data instead
-            array = xp.zeros_like(array, device="cpu")
-        else:
-            array = to_device(array, "cpu")
+        array = to_device(array, "cpu")
     if is_array_api_strict_namespace(xp):
         cpu: Device = xp.Device("CPU_DEVICE")
         array = to_device(array, cpu)
@@ -150,6 +168,8 @@ def xp_assert_equal(
     numpy.testing.assert_array_equal : Similar function for NumPy arrays.
     """
     xp = _check_ns_shape_dtype(actual, desired, check_dtype, check_shape, check_scalar)
+    if not _is_materializable(actual):
+        return
     actual_np = as_numpy_array(actual, xp=xp)
     desired_np = as_numpy_array(desired, xp=xp)
     np.testing.assert_array_equal(actual_np, desired_np, err_msg=err_msg)
@@ -185,6 +205,8 @@ def xp_assert_less(
     numpy.testing.assert_array_equal : Similar function for NumPy arrays.
     """
     xp = _check_ns_shape_dtype(x, y, check_dtype, check_shape, check_scalar)
+    if not _is_materializable(x):
+        return
     x_np = as_numpy_array(x, xp=xp)
     y_np = as_numpy_array(y, xp=xp)
     np.testing.assert_array_less(x_np, y_np, err_msg=err_msg)
@@ -233,6 +255,8 @@ def xp_assert_close(
     The default `atol` and `rtol` differ from `xp.all(xpx.isclose(a, b))`.
     """
     xp = _check_ns_shape_dtype(actual, desired, check_dtype, check_shape, check_scalar)
+    if not _is_materializable(actual):
+        return
 
     if rtol is None:
         if xp.isdtype(actual.dtype, ("real floating", "complex floating")):

--- a/src/array_api_extra/_lib/_utils/_helpers.py
+++ b/src/array_api_extra/_lib/_utils/_helpers.py
@@ -332,7 +332,7 @@ def capabilities(xp: ModuleType, *, device: Device | None = None) -> dict[str, i
     if is_torch_namespace(xp):
         # FIXME https://github.com/data-apis/array-api/issues/945
         device = xp.get_default_device() if device is None else xp.device(device)
-        if cast(Any, device).type == "meta":  # type: ignore[explicit-any]
+        if device.type == "meta":  # type: ignore[union-attr]  # pyright: ignore[reportAttributeAccessIssue,reportOptionalMemberAccess]
             out = out.copy()
             out["boolean indexing"] = False
             out["data-dependent shapes"] = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,9 @@ def device(
     Where possible, return a device that is not the default one.
     """
     if library == Backend.ARRAY_API_STRICT:
-        d = xp.Device("device1")
-        assert get_device(xp.empty(0)) != d
-        return d
+        return xp.Device("device1")
+    if library == Backend.TORCH:
+        return xp.device("meta")
+    if library == Backend.TORCH_GPU:
+        return xp.device("cpu")
     return get_device(xp.empty(0))

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -731,9 +731,6 @@ class TestIsClose:
         b = xp.asarray([1e-9, 1e-4, xp.nan], device=device)
         res = isclose(a, b, equal_nan=equal_nan)
         assert get_device(res) == device
-        xp_assert_equal(
-            isclose(a, b, equal_nan=equal_nan), xp.asarray([True, False, equal_nan])
-        )
 
 
 class TestKron:
@@ -996,6 +993,9 @@ class TestSetDiff1D:
             _ = setdiff1d(0, 0, assume_unique=assume_unique)
 
     @assume_unique
+    @pytest.mark.skip_xp_backend(
+        Backend.TORCH, reason="device='meta' does not support unknown shapes"
+    )
     def test_device(self, xp: ModuleType, device: Device, assume_unique: bool):
         x1 = xp.asarray([3, 8, 20], device=device)
         x2 = xp.asarray([2, 3, 4], device=device)

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -279,6 +279,9 @@ def test_lazy_apply_none_shape_broadcast(xp: ModuleType):
                 ),
                 pytest.mark.skip_xp_backend(Backend.CUPY, reason="device->host copy"),
                 pytest.mark.skip_xp_backend(
+                    Backend.TORCH, reason="materialize 'meta' device"
+                ),
+                pytest.mark.skip_xp_backend(
                     Backend.TORCH_GPU, reason="device->host copy"
                 ),
                 pytest.mark.skip_xp_backend(Backend.SPARSE, reason="densification"),

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -39,10 +39,22 @@ param_assert_equal_close = pytest.mark.parametrize(
 )
 
 
-def test_as_numpy_array(xp: ModuleType, device: Device):
-    x = xp.asarray([1, 2, 3], device=device)
-    y = as_numpy_array(x, xp=xp)
-    assert isinstance(y, np.ndarray)
+class TestAsNumPyArray:
+    def test_basic(self, xp: ModuleType):
+        x = xp.asarray([1, 2, 3])
+        y = as_numpy_array(x, xp=xp)
+        xp_assert_equal(y, np.asarray([1, 2, 3]))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+    def test_device(self, xp: ModuleType, library: Backend, device: Device):
+        x = xp.asarray([1, 2, 3], device=device)
+        actual = as_numpy_array(x, xp=xp)
+        if library is Backend.TORCH:
+            assert device.type == "meta"  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
+            expect = np.asarray([0, 0, 0])
+        else:
+            expect = np.asarray([1, 2, 3])
+
+        xp_assert_equal(actual, expect)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no isdtype", strict=False)


### PR DESCRIPTION
- Add support for PyTorch `meta` device. Specifically, this PR fixes:
  - `apply_where`
  - `nunique`
  - `_testing.xp_assert_equal`
  - `_testing.xp_assert_close`
  - `_testing.xp_assert_less`
- Test PyTorch input->output device propagation
  - when input device is `meta` but default device is `cpu`;
  - on pixi environments `tests_cuda` and `dev_cuda`, when input device is `cpu` but default device is `cuda`

XREF https://github.com/data-apis/array-api/issues/945