### PR TITLE
ENH: `at`: add `__setitem__` fancy indexing fallback

### DIFF
--- a/src/array_api_extra/_lib/_at.py
+++ b/src/array_api_extra/_lib/_at.py
@@ -364,7 +364,7 @@ class at:  # pylint: disable=invalid-name  # numpydoc ignore=PR02
             # Vectorize the operation using boolean indexing
             # For non-unique indices, take the last occurrence. This requires creating
             # masks for x and y that create matching shapes.
-            unique_indices, first_occurrence_mask = xp.unique_inverse(idx)
+            unique_indices, _ = xp.unique_inverse(idx)
             x_mask = xp.any(xp.arange(x.shape[0])[..., None] == unique_indices, axis=-1)
             # Get last occurrence of each unique index
             cmp = unique_indices[:, None] == unique_indices[None, :]

--- a/src/array_api_extra/_lib/_at.py
+++ b/src/array_api_extra/_lib/_at.py
@@ -152,8 +152,8 @@ class at:  # pylint: disable=invalid-name  # numpydoc ignore=PR02
 
     For frameworks that don't support fancy indexing by default, e.g. array-api-strict,
     we implement a workaround for 1D integer indices and ``xpx.at().set``. Assignments
-    with multiple occurences of the same index always choose the last occurence. This is
-    consistent with numpy's behaviour, e.g.::
+    with multiple occurrences of the same index always choose the last occurrence. This
+    is consistent with numpy's behaviour, e.g.::
 
         >>> import numpy as np
         >>> import array_api_strict as xp

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -306,6 +306,18 @@ def test_setitem_int_array_index(xp: ModuleType):
     expect = xp.asarray([[4.0, 5.0], [2.0, 3.0]])
     z = at_op(x, idx, _AtOp.SET, y)
     xp_assert_equal(z, expect)
+    # Scalar
+    x = xp.asarray([0.0, 1.0])
+    z = at_op(x, xp.asarray([1]), _AtOp.SET, 2.0)
+    xp_assert_equal(z, xp.asarray([0.0, 2.0]))
+    # 0D array
+    x = xp.asarray([0.0, 1.0])
+    z = at_op(x, xp.asarray([1]), _AtOp.SET, xp.asarray(2.0))
+    xp_assert_equal(z, xp.asarray([0.0, 2.0]))
+    # Negative indices
+    x = xp.asarray([0.0, 1.0])
+    z = at_op(x, xp.asarray([-1]), _AtOp.SET, 2.0)
+    xp_assert_equal(z, xp.asarray([0.0, 2.0]))
 
 
 @pytest.mark.parametrize("bool_mask", [False, True])

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -288,16 +288,16 @@ def test_setitem_int_array_index(xp: ModuleType):
     assert isinstance(z, type(x))
     xp_assert_equal(z, expect)
     # Single dimension, non-unique index
-    x = xp.asarray([0.0, 1.0])
-    y = xp.asarray([2.0, 3.0])
-    idx = xp.asarray([1, 1])
+    x = xp.asarray([0.0, 1.0, 2.0])
+    y = xp.asarray([3.0, 4.0, 5.0])
+    idx = xp.asarray([0, 1, 0])
     device_str = str(get_device(x)).lower()
     # GPU arrays generally use the first element, but JAX with float64 enabled uses the
     # last element.
     if ("gpu" in device_str or "cuda" in device_str) and not is_jax_namespace(xp):
-        expect = xp.asarray([0.0, 2.0])
+        expect = xp.asarray([3.0, 4.0, 2.0])
     else:
-        expect = xp.asarray([0.0, 3.0])  # CPU arrays use the last
+        expect = xp.asarray([5.0, 4.0, 2.0])  # CPU arrays use the last
     z = at_op(x, idx, _AtOp.SET, y)
     assert isinstance(z, type(x))
     xp_assert_equal(z, expect)

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -327,13 +327,13 @@ def test_setitem_int_array_index(xp: ModuleType):
     if is_array_api_strict_namespace(xp) or is_numpy_namespace(xp):
         # Test wrong shapes
         with pytest.raises(ValueError, match="shape"):
-            at_op(xp.asarray([0]), xp.asarray([0]), _AtOp.SET, xp.asarray([1, 2]))
+            _ = at_op(xp.asarray([0]), xp.asarray([0]), _AtOp.SET, xp.asarray([1, 2]))
         # Test positive out of bounds index
         with pytest.raises(IndexError, match="out of bounds"):
-            at_op(xp.asarray([0]), xp.asarray([1]), _AtOp.SET, xp.asarray([1]))
+            _ = at_op(xp.asarray([0]), xp.asarray([1]), _AtOp.SET, xp.asarray([1]))
         # Test negative out of bounds index
         with pytest.raises(IndexError, match="out of bounds"):
-            at_op(xp.asarray([0]), xp.asarray([-2]), _AtOp.SET, xp.asarray([1]))
+            _ = at_op(xp.asarray([0]), xp.asarray([-2]), _AtOp.SET, xp.asarray([1]))
 
 
 @pytest.mark.parametrize("bool_mask", [False, True])


### PR DESCRIPTION
Fancy indexing is currently not supported for `__setitem__`, which blocks some PRs in scipy (https://github.com/scipy/scipy/pull/23425).

As discussed in https://github.com/data-apis/array-api/issues/864#issuecomment-3167352347, all frameworks of the array api already implement this feature, but not necessarily in a consistent manner for duplicate indices. It is currently not part of the standard. This PR adds a workaround for array api strict to allow fancy indexing in `xpx.at(x, ...)`.