### PR TITLE
MAINT: renovate to skip JAX

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
     "description": "Block PRs for updates blocked on dropping Python 3.10.",
     "matchManagers": ["pixi"],
     "matchUpdateTypes": ["major", "minor"],
-    "matchPackageNames": ["numpy", "sphinx", "ipython", "sphinx-autodoc-typehints"],
+    "matchPackageNames": ["numpy", "jax", "jaxlib",  "sphinx", "ipython", "sphinx-autodoc-typehints"],
     "enabled": false
   }, {
     "description": "Group Dask packages.",

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
     "description": "Block PRs for updates blocked on dropping Python 3.10.",
     "matchManagers": ["pixi"],
     "matchUpdateTypes": ["major", "minor"],
-    "matchPackageNames": ["numpy", "jax", "jaxlib",  "sphinx", "ipython", "sphinx-autodoc-typehints"],
+    "matchPackageNames": ["numpy", "jax", "jaxlib", "sphinx", "ipython", "sphinx-autodoc-typehints"],
     "enabled": false
   }, {
     "description": "Group Dask packages.",


### PR DESCRIPTION
jax 0.7.0 and later is incompatible with Python 3.10.
jax.0.6.2 and later segfaults on CUDA. Note that CUDA is not in CI.

I've never tampered with renovate before so I'm not 100% sure about what I'm doing.