### PR TITLE
Add partition and argpartition functions

### DIFF
--- a/src/array_api_extra/__init__.py
+++ b/src/array_api_extra/__init__.py
@@ -1,6 +1,13 @@
 """Extra array functions built on top of the array API standard."""
 
-from ._delegation import isclose, nan_to_num, one_hot, pad
+from ._delegation import (
+    argpartition,
+    isclose,
+    nan_to_num,
+    one_hot,
+    pad,
+    partition,
+)
 from ._lib._at import at
 from ._lib._funcs import (
     apply_where,
@@ -23,6 +30,7 @@ __version__ = "0.9.1.dev0"
 __all__ = [
     "__version__",
     "apply_where",
+    "argpartition",
     "at",
     "atleast_nd",
     "broadcast_shapes",
@@ -37,6 +45,7 @@ __all__ = [
     "nunique",
     "one_hot",
     "pad",
+    "partition",
     "setdiff1d",
     "sinc",
 ]

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -1029,3 +1029,23 @@ def sinc(x: Array, /, *, xp: ModuleType | None = None) -> Array:
         xp.asarray(xp.finfo(x.dtype).eps, dtype=x.dtype, device=_compat.device(x)),
     )
     return xp.sin(y) / y
+
+
+def partition(  # numpydoc ignore=PR01,RT01
+    x: Array,
+    kth: int,  # noqa: ARG001
+    *,
+    xp: ModuleType,
+) -> Array:
+    """See docstring in `array_api_extra._delegation.py`."""
+    return xp.sort(x, stable=False)
+
+
+def argpartition(  # numpydoc ignore=PR01,RT01
+    x: Array,
+    kth: int,  # noqa: ARG001
+    *,
+    xp: ModuleType,
+) -> Array:
+    """See docstring in `array_api_extra._delegation.py`."""
+    return xp.argsort(x, stable=False)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -12,6 +12,7 @@ from hypothesis import strategies as st
 
 from array_api_extra import (
     apply_where,
+    argpartition,
     at,
     atleast_nd,
     broadcast_shapes,
@@ -25,6 +26,7 @@ from array_api_extra import (
     nunique,
     one_hot,
     pad,
+    partition,
     setdiff1d,
     sinc,
 )
@@ -1298,3 +1300,18 @@ class TestSinc:
 
     def test_xp(self, xp: ModuleType):
         xp_assert_equal(sinc(xp.asarray(0.0), xp=xp), xp.asarray(1.0))
+
+
+class TestPartition:
+    def test_basic(self, xp: ModuleType):
+        # Using 0-dimensional array
+        rng = np.random.default_rng(2847)
+
+        for _ in range(100):
+            n = rng.integers(1, 1000)
+            x = xp.asarray(rng.random(size=n))
+            k = int(rng.integers(1, n - 1))
+            y = partition(x, k)
+            assert xp.max(y[:k]) <= xp.min(y[k:])
+            y = x[argpartition(x, k)]
+            assert xp.max(y[:k]) <= xp.min(y[k:])


### PR DESCRIPTION
WIP: For now, only supports 1-d, but I will rework it to support nd inputs.

Also: I don't know how to handle the sparse backend (`is_pydata_sparse_namespace`): it has no `argsort`...