### PR TITLE
ENH: cov: expose correction and weights parameters

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "jax": ("https://docs.jax.dev/en/latest", None),
     "pytest": ("https://docs.pytest.org/en/stable/", None),
+    "torch": ("https://docs.pytorch.org/docs/stable", None),
 }
 
 nitpick_ignore = [

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -81,7 +81,16 @@ def atleast_nd(x: Array, /, *, ndim: int, xp: ModuleType | None = None) -> Array
     return _funcs.atleast_nd(x, ndim=ndim, xp=xp)
 
 
-def cov(m: Array, /, *, xp: ModuleType | None = None) -> Array:
+def cov(
+    m: Array,
+    /,
+    *,
+    axis: int = -1,
+    correction: int | float = 1,
+    frequency_weights: Array | None = None,
+    weights: Array | None = None,
+    xp: ModuleType | None = None,
+) -> Array:
     """
     Estimate a covariance matrix (or a stack of covariance matrices).
 
@@ -92,16 +101,37 @@ def cov(m: Array, /, *, xp: ModuleType | None = None) -> Array:
     :math:`x_i` and :math:`x_j`. The element :math:`C_{ii}` is the variance
     of :math:`x_i`.
 
-    With the exception of supporting batch input, this provides a subset of
-    the functionality of ``numpy.cov``.
+    Extends ``numpy.cov`` with support for batch input and array-api
+    backends. Naming follows the array-api conventions used elsewhere in
+    this library (``axis``, ``correction``) rather than the numpy spellings
+    (``rowvar``, ``bias``, ``ddof``); see Notes for the mapping.
 
     Parameters
     ----------
     m : array
         An array of shape ``(..., N, M)`` whose innermost two dimensions
-        contain *M* observations of *N* variables. That is,
-        each row of `m` represents a variable, and each column a single
-        observation of all those variables.
+        contain *M* observations of *N* variables by default. The axis of
+        observations is controlled by `axis`.
+    axis : int, optional
+        Axis of `m` containing the observations. Default: ``-1`` (the last
+        axis), matching the array-api convention. Use ``axis=-2`` (or ``0``
+        for 2-D input) to treat each column as a variable, which
+        corresponds to ``rowvar=False`` in ``numpy.cov``.
+    correction : int or float, optional
+        Degrees of freedom correction: normalization divides by
+        ``N - correction`` (for unweighted input). Default: ``1``, which
+        gives the unbiased estimate (matches ``numpy.cov`` default of
+        ``bias=False``). Set to ``0`` for the biased estimate (``N``
+        normalization). Corresponds to ``ddof`` in ``numpy.cov`` and to
+        ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
+    frequency_weights : array, optional
+        1-D array of integer frequency weights: the number of times each
+        observation is repeated. Corresponds to ``fweights`` in
+        ``numpy.cov``/``torch.cov``.
+    weights : array, optional
+        1-D array of observation-vector weights (analytic weights). Larger
+        values mark more important observations. Corresponds to
+        ``aweights`` in ``numpy.cov``/``torch.cov``.
     xp : array_namespace, optional
         The standard-compatible namespace for `m`. Default: infer.
 
@@ -110,6 +140,23 @@ def cov(m: Array, /, *, xp: ModuleType | None = None) -> Array:
     array
         An array having shape (..., N, N) whose innermost two dimensions represent
         the covariance matrix of the variables.
+
+    Notes
+    -----
+    Mapping from ``numpy.cov`` to this function::
+
+        numpy.cov(m, rowvar=True)           -> cov(m, axis=-1)   # default
+        numpy.cov(m, rowvar=False)          -> cov(m, axis=-2)
+        numpy.cov(m, bias=True)             -> cov(m, correction=0)
+        numpy.cov(m, ddof=k)                -> cov(m, correction=k)
+        numpy.cov(m, fweights=f)            -> cov(m, frequency_weights=f)
+        numpy.cov(m, aweights=a)            -> cov(m, weights=a)
+
+    Unlike ``numpy.cov``, a ``RuntimeWarning`` for non-positive effective
+    degrees of freedom is only emitted on the unweighted path. The
+    weighted path omits the check so that lazy backends (e.g. Dask) can
+    stay lazy end-to-end; choose ``correction`` and weights such that the
+    effective normalizer is positive.
 
     Examples
     --------
@@ -164,16 +211,57 @@ def cov(m: Array, /, *, xp: ModuleType | None = None) -> Array:
     if xp is None:
         xp = array_namespace(m)
 
-    if (
-        is_numpy_namespace(xp)
-        or is_cupy_namespace(xp)
-        or is_torch_namespace(xp)
-        or is_dask_namespace(xp)
-        or is_jax_namespace(xp)
-    ) and m.ndim <= 2:
-        return xp.cov(m)
+    # Validate axis against m.ndim.
+    ndim = max(m.ndim, 1)
+    if not -ndim <= axis < ndim:
+        msg = f"axis {axis} is out of bounds for array of dimension {m.ndim}"
+        raise IndexError(msg)
 
-    return _funcs.cov(m, xp=xp)
+    # Normalize: observations on the last axis. After this, every backend
+    # sees the same convention and we never need to deal with `rowvar`.
+    if m.ndim >= 2 and axis not in (-1, m.ndim - 1):
+        m = xp.moveaxis(m, axis, -1)
+
+    # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
+    # requires integer `correction`. For non-integer-valued `correction`,
+    # fall through to the generic implementation.
+    integer_correction = isinstance(correction, int) or correction.is_integer()
+    has_weights = frequency_weights is not None or weights is not None
+
+    if m.ndim <= 2 and integer_correction:
+        if is_torch_namespace(xp):
+            device = get_device(m)
+            fw = (
+                None
+                if frequency_weights is None
+                else xp.asarray(frequency_weights, device=device)
+            )
+            aw = None if weights is None else xp.asarray(weights, device=device)
+            return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
+        # `dask.array.cov` forces `.compute()` whenever weights are given:
+        # its internal `if fact <= 0` check on a lazy 0-D scalar triggers
+        # materialization. Route to the generic impl, which is fully lazy
+        # because it only does sum/matmul and skips that scalar check.
+        if (
+            is_numpy_namespace(xp)
+            or is_cupy_namespace(xp)
+            or is_jax_namespace(xp)
+            or (is_dask_namespace(xp) and not has_weights)
+        ):
+            return xp.cov(
+                m,
+                ddof=int(correction),
+                fweights=frequency_weights,
+                aweights=weights,
+            )
+
+    return _funcs.cov(
+        m,
+        correction=correction,
+        frequency_weights=frequency_weights,
+        weights=weights,
+        xp=xp,
+    )
 
 
 def create_diagonal(

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -230,9 +230,7 @@ def cov(
 
     if m.ndim <= 2 and integer_correction:
         if is_torch_namespace(xp):
-            fw = (
-                None if frequency_weights is None else xp.asarray(frequency_weights)
-            )
+            fw = None if frequency_weights is None else xp.asarray(frequency_weights)
             aw = None if weights is None else xp.asarray(weights)
             return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -222,20 +222,6 @@ def cov(
     if m.ndim >= 2 and axis not in (-1, m.ndim - 1):
         m = xp.moveaxis(m, axis, -1)
 
-    # Validate weight shapes (eager metadata, lazy-safe). Value-based
-    # checks (non-negative, integer dtype) are intentionally skipped so
-    # lazy backends don't trigger compute -- same tradeoff as dask.cov.
-    n_obs = m.shape[-1]
-    for name, w in (("fweights", fweights), ("aweights", aweights)):
-        if w is None:
-            continue
-        if w.ndim != 1:
-            msg = f"`{name}` must be 1-D, got ndim={w.ndim}"
-            raise ValueError(msg)
-        if w.shape[0] != n_obs:
-            msg = f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
-            raise ValueError(msg)
-
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -230,13 +230,10 @@ def cov(
 
     if m.ndim <= 2 and integer_correction:
         if is_torch_namespace(xp):
-            device = get_device(m)
             fw = (
-                None
-                if frequency_weights is None
-                else xp.asarray(frequency_weights, device=device)
+                None if frequency_weights is None else xp.asarray(frequency_weights)
             )
-            aw = None if weights is None else xp.asarray(weights, device=device)
+            aw = None if weights is None else xp.asarray(weights)
             return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:
         # its internal `if fact <= 0` check on a lazy 0-D scalar triggers

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -87,8 +87,8 @@ def cov(
     *,
     axis: int = -1,
     correction: int | float = 1,
-    frequency_weights: Array | None = None,
-    weights: Array | None = None,
+    fweights: Array | None = None,
+    aweights: Array | None = None,
     xp: ModuleType | None = None,
 ) -> Array:
     """
@@ -126,12 +126,12 @@ def cov(
         ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
     fweights : array, optional
         1-D array of integer frequency weights: the number of times each
-        observation is repeated. Corresponds to ``fweights`` in
+        observation is repeated. Same as ``fweights`` in
         ``numpy.cov``/``torch.cov``.
     aweights : array, optional
         1-D array of observation-vector weights (analytic weights). Larger
-        values mark more important observations. Corresponds to
-        ``aweights`` in ``numpy.cov``/``torch.cov``.
+        values mark more important observations. Same as ``aweights`` in
+        ``numpy.cov``/``torch.cov``.
     xp : array_namespace, optional
         The standard-compatible namespace for `m`. Default: infer.
 
@@ -149,8 +149,8 @@ def cov(
         numpy.cov(m, rowvar=False)          -> cov(m, axis=-2)
         numpy.cov(m, bias=True)             -> cov(m, correction=0)
         numpy.cov(m, ddof=k)                -> cov(m, correction=k)
-        numpy.cov(m, fweights=f)            -> cov(m, frequency_weights=f)
-        numpy.cov(m, aweights=a)            -> cov(m, weights=a)
+        numpy.cov(m, fweights=f)            -> cov(m, fweights=f)
+        numpy.cov(m, aweights=a)            -> cov(m, aweights=a)
 
     Unlike ``numpy.cov``, a ``RuntimeWarning`` for non-positive effective
     degrees of freedom is only emitted on the unweighted path. The
@@ -226,12 +226,12 @@ def cov(
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.
     integer_correction = isinstance(correction, int) or correction.is_integer()
-    has_weights = frequency_weights is not None or weights is not None
+    has_weights = fweights is not None or aweights is not None
 
     if m.ndim <= 2 and integer_correction:
         if is_torch_namespace(xp):
-            fw = None if frequency_weights is None else xp.asarray(frequency_weights)
-            aw = None if weights is None else xp.asarray(weights)
+            fw = None if fweights is None else xp.asarray(fweights)
+            aw = None if aweights is None else xp.asarray(aweights)
             return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:
         # its internal `if fact <= 0` check on a lazy 0-D scalar triggers
@@ -246,15 +246,15 @@ def cov(
             return xp.cov(
                 m,
                 ddof=int(correction),
-                fweights=frequency_weights,
-                aweights=weights,
+                fweights=fweights,
+                aweights=aweights,
             )
 
     return _funcs.cov(
         m,
         correction=correction,
-        frequency_weights=frequency_weights,
-        weights=weights,
+        fweights=fweights,
+        aweights=aweights,
         xp=xp,
     )
 

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -124,11 +124,11 @@ def cov(
         ``bias=False``). Set to ``0`` for the biased estimate (``N``
         normalization). Corresponds to ``ddof`` in ``numpy.cov`` and to
         ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
-    frequency_weights : array, optional
+    fweights : array, optional
         1-D array of integer frequency weights: the number of times each
         observation is repeated. Corresponds to ``fweights`` in
         ``numpy.cov``/``torch.cov``.
-    weights : array, optional
+    aweights : array, optional
         1-D array of observation-vector weights (analytic weights). Larger
         values mark more important observations. Corresponds to
         ``aweights`` in ``numpy.cov``/``torch.cov``.

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -222,6 +222,22 @@ def cov(
     if m.ndim >= 2 and axis not in (-1, m.ndim - 1):
         m = xp.moveaxis(m, axis, -1)
 
+    # Validate weight shapes (eager metadata, lazy-safe). Value-based
+    # checks (non-negative, integer dtype) are intentionally skipped so
+    # lazy backends don't trigger compute -- same tradeoff as dask.cov.
+    n_obs = m.shape[-1]
+    for name, w in (("fweights", fweights), ("aweights", aweights)):
+        if w is None:
+            continue
+        if w.ndim != 1:
+            msg = f"`{name}` must be 1-D, got ndim={w.ndim}"
+            raise ValueError(msg)
+        if w.shape[0] != n_obs:
+            msg = (
+                f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
+            )
+            raise ValueError(msg)
+
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -209,7 +209,7 @@ def cov(
     """
 
     if xp is None:
-        xp = array_namespace(m)
+        xp = array_namespace(m, fweights, aweights)
 
     # Validate axis against m.ndim.
     ndim = max(m.ndim, 1)
@@ -233,9 +233,7 @@ def cov(
             msg = f"`{name}` must be 1-D, got ndim={w.ndim}"
             raise ValueError(msg)
         if w.shape[0] != n_obs:
-            msg = (
-                f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
-            )
+            msg = f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
             raise ValueError(msg)
 
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -169,7 +169,16 @@ def broadcast_shapes(
     return _funcs.broadcast_shapes(*shapes)
 
 
-def cov(m: Array, /, *, xp: ArrayNamespace | None = None) -> Array:
+def cov(
+    m: Array,
+    /,
+    *,
+    axis: int = -1,
+    correction: int | float = 1,
+    frequency_weights: Array | None = None,
+    weights: Array | None = None,
+    xp: ArrayNamespace | None = None,
+) -> Array:
     """
     Estimate a covariance matrix (or a stack of covariance matrices).
 
@@ -180,16 +189,37 @@ def cov(m: Array, /, *, xp: ArrayNamespace | None = None) -> Array:
     :math:`x_i` and :math:`x_j`. The element :math:`C_{ii}` is the variance
     of :math:`x_i`.
 
-    With the exception of supporting batch input, this provides a subset of
-    the functionality of ``numpy.cov``.
+    Extends ``numpy.cov`` with support for batch input and array-api
+    backends. Naming follows the array-api conventions used elsewhere in
+    this library (``axis``, ``correction``) rather than the numpy spellings
+    (``rowvar``, ``bias``, ``ddof``); see Notes for the mapping.
 
     Parameters
     ----------
     m : array
         An array of shape ``(..., N, M)`` whose innermost two dimensions
-        contain *M* observations of *N* variables. That is,
-        each row of `m` represents a variable, and each column a single
-        observation of all those variables.
+        contain *M* observations of *N* variables by default. The axis of
+        observations is controlled by `axis`.
+    axis : int, optional
+        Axis of `m` containing the observations. Default: ``-1`` (the last
+        axis), matching the array-api convention. Use ``axis=-2`` (or ``0``
+        for 2-D input) to treat each column as a variable, which
+        corresponds to ``rowvar=False`` in ``numpy.cov``.
+    correction : int or float, optional
+        Degrees of freedom correction: normalization divides by
+        ``N - correction`` (for unweighted input). Default: ``1``, which
+        gives the unbiased estimate (matches ``numpy.cov`` default of
+        ``bias=False``). Set to ``0`` for the biased estimate (``N``
+        normalization). Corresponds to ``ddof`` in ``numpy.cov`` and to
+        ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
+    frequency_weights : array, optional
+        1-D array of integer frequency weights: the number of times each
+        observation is repeated. Corresponds to ``fweights`` in
+        ``numpy.cov``/``torch.cov``.
+    weights : array, optional
+        1-D array of observation-vector weights (analytic weights). Larger
+        values mark more important observations. Corresponds to
+        ``aweights`` in ``numpy.cov``/``torch.cov``.
     xp : array_namespace, optional
         The standard-compatible namespace for `m`. Default: infer.
 
@@ -198,6 +228,23 @@ def cov(m: Array, /, *, xp: ArrayNamespace | None = None) -> Array:
     array
         An array having shape (..., N, N) whose innermost two dimensions represent
         the covariance matrix of the variables.
+
+    Notes
+    -----
+    Mapping from ``numpy.cov`` to this function::
+
+        numpy.cov(m, rowvar=True)           -> cov(m, axis=-1)   # default
+        numpy.cov(m, rowvar=False)          -> cov(m, axis=-2)
+        numpy.cov(m, bias=True)             -> cov(m, correction=0)
+        numpy.cov(m, ddof=k)                -> cov(m, correction=k)
+        numpy.cov(m, fweights=f)            -> cov(m, frequency_weights=f)
+        numpy.cov(m, aweights=a)            -> cov(m, weights=a)
+
+    Unlike ``numpy.cov``, a ``RuntimeWarning`` for non-positive effective
+    degrees of freedom is only emitted on the unweighted path. The
+    weighted path omits the check so that lazy backends (e.g. Dask) can
+    stay lazy end-to-end; choose ``correction`` and weights such that the
+    effective normalizer is positive.
 
     Examples
     --------
@@ -251,16 +298,57 @@ def cov(m: Array, /, *, xp: ArrayNamespace | None = None) -> Array:
     if xp is None:
         xp = array_namespace(m)
 
-    if (
-        is_numpy_namespace(xp)
-        or is_cupy_namespace(xp)
-        or is_torch_namespace(xp)
-        or is_dask_namespace(xp)
-        or is_jax_namespace(xp)
-    ) and m.ndim <= 2:
-        return xp.cov(m)
+    # Validate axis against m.ndim.
+    ndim = max(m.ndim, 1)
+    if not -ndim <= axis < ndim:
+        msg = f"axis {axis} is out of bounds for array of dimension {m.ndim}"
+        raise IndexError(msg)
 
-    return _funcs.cov(m, xp=xp)
+    # Normalize: observations on the last axis. After this, every backend
+    # sees the same convention and we never need to deal with `rowvar`.
+    if m.ndim >= 2 and axis not in (-1, m.ndim - 1):
+        m = xp.moveaxis(m, axis, -1)
+
+    # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
+    # requires integer `correction`. For non-integer-valued `correction`,
+    # fall through to the generic implementation.
+    integer_correction = isinstance(correction, int) or correction.is_integer()
+    has_weights = frequency_weights is not None or weights is not None
+
+    if m.ndim <= 2 and integer_correction:
+        if is_torch_namespace(xp):
+            device = get_device(m)
+            fw = (
+                None
+                if frequency_weights is None
+                else xp.asarray(frequency_weights, device=device)
+            )
+            aw = None if weights is None else xp.asarray(weights, device=device)
+            return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
+        # `dask.array.cov` forces `.compute()` whenever weights are given:
+        # its internal `if fact <= 0` check on a lazy 0-D scalar triggers
+        # materialization. Route to the generic impl, which is fully lazy
+        # because it only does sum/matmul and skips that scalar check.
+        if (
+            is_numpy_namespace(xp)
+            or is_cupy_namespace(xp)
+            or is_jax_namespace(xp)
+            or (is_dask_namespace(xp) and not has_weights)
+        ):
+            return xp.cov(
+                m,
+                ddof=int(correction),
+                fweights=frequency_weights,
+                aweights=weights,
+            )
+
+    return _funcs.cov(
+        m,
+        correction=correction,
+        frequency_weights=frequency_weights,
+        weights=weights,
+        xp=xp,
+    )
 
 
 def create_diagonal(

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -186,9 +186,9 @@ def cov(
     :math:`x_i` and :math:`x_j`. The element :math:`C_{ii}` is the variance
     of :math:`x_i`.
 
-    Extends ``numpy.cov`` with support for batch input and array-api
-    backends. Naming follows the array-api conventions used elsewhere in
-    this library (``axis``, ``correction``) rather than the numpy spellings
+    Extends ``numpy.cov`` with support for batch input.
+    Naming follows the array API conventions used elsewhere in
+    this library (``axis``, ``correction``) rather than the NumPy spellings
     (``rowvar``, ``bias``, ``ddof``); see Notes for the mapping.
 
     Parameters
@@ -244,11 +244,11 @@ def cov(
         numpy.cov(m, fweights=f)            -> cov(m, fweights=f)
         numpy.cov(m, aweights=a)            -> cov(m, aweights=a)
 
-    Unlike ``numpy.cov``, a ``RuntimeWarning`` for non-positive effective
-    degrees of freedom is only emitted on the unweighted path. The
-    weighted path omits the check so that lazy backends (e.g. Dask) can
-    stay lazy end-to-end; choose ``correction`` and weights such that the
-    effective normalizer is positive.
+    A ``RuntimeWarning`` is emitted for non-positive effective degrees of
+    freedom when the effective normalizer can be checked without materializing
+    a lazy array. When the normalizer itself is lazy (e.g. for weighted Dask
+    inputs), this check is skipped; choose ``correction`` and weights such that
+    it is positive.
 
     Examples
     --------

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -315,13 +315,10 @@ def cov(
 
     if m.ndim <= 2 and integer_correction:
         if is_torch_namespace(xp):
-            device = get_device(m)
             fw = (
-                None
-                if frequency_weights is None
-                else xp.asarray(frequency_weights, device=device)
+                None if frequency_weights is None else xp.asarray(frequency_weights)
             )
-            aw = None if weights is None else xp.asarray(weights, device=device)
+            aw = None if weights is None else xp.asarray(weights)
             return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:
         # its internal `if fact <= 0` check on a lazy 0-D scalar triggers

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -174,7 +174,7 @@ def cov(
     /,
     *,
     axis: int = -1,
-    correction: int | float = 1,
+    correction: float = 1,
     fweights: Array | None = None,
     aweights: Array | None = None,
     xp: ArrayNamespace | None = None,

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -309,6 +309,22 @@ def cov(
     if m.ndim >= 2 and axis not in (-1, m.ndim - 1):
         m = xp.moveaxis(m, axis, -1)
 
+    # Validate weight shapes (eager metadata, lazy-safe). Value-based
+    # checks (non-negative, integer dtype) are intentionally skipped so
+    # lazy backends don't trigger compute -- same tradeoff as dask.cov.
+    n_obs = m.shape[-1]
+    for name, w in (("fweights", fweights), ("aweights", aweights)):
+        if w is None:
+            continue
+        if w.ndim != 1:
+            msg = f"`{name}` must be 1-D, got ndim={w.ndim}"
+            raise ValueError(msg)
+        if w.shape[0] != n_obs:
+            msg = (
+                f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
+            )
+            raise ValueError(msg)
+
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -307,20 +307,6 @@ def cov(
     if m.ndim >= 2 and axis not in (-1, m.ndim - 1):
         m = xp.moveaxis(m, axis, -1)
 
-    # Validate weight shapes (eager metadata, lazy-safe). Value-based
-    # checks (non-negative, integer dtype) are intentionally skipped so
-    # lazy backends don't trigger compute -- same tradeoff as dask.cov.
-    n_obs = m.shape[-1]
-    for name, w in (("fweights", fweights), ("aweights", aweights)):
-        if w is None:
-            continue
-        if w.ndim != 1:
-            msg = f"`{name}` must be 1-D, got ndim={w.ndim}"
-            raise ValueError(msg)
-        if w.shape[0] != n_obs:
-            msg = f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
-            raise ValueError(msg)
-
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -175,8 +175,8 @@ def cov(
     *,
     axis: int = -1,
     correction: int | float = 1,
-    frequency_weights: Array | None = None,
-    weights: Array | None = None,
+    fweights: Array | None = None,
+    aweights: Array | None = None,
     xp: ArrayNamespace | None = None,
 ) -> Array:
     """
@@ -214,12 +214,12 @@ def cov(
         ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
     fweights : array, optional
         1-D array of integer frequency weights: the number of times each
-        observation is repeated. Corresponds to ``fweights`` in
+        observation is repeated. Same as ``fweights`` in
         ``numpy.cov``/``torch.cov``.
     aweights : array, optional
         1-D array of observation-vector weights (analytic weights). Larger
-        values mark more important observations. Corresponds to
-        ``aweights`` in ``numpy.cov``/``torch.cov``.
+        values mark more important observations. Same as ``aweights`` in
+        ``numpy.cov``/``torch.cov``.
     xp : array_namespace, optional
         The standard-compatible namespace for `m`. Default: infer.
 
@@ -237,8 +237,8 @@ def cov(
         numpy.cov(m, rowvar=False)          -> cov(m, axis=-2)
         numpy.cov(m, bias=True)             -> cov(m, correction=0)
         numpy.cov(m, ddof=k)                -> cov(m, correction=k)
-        numpy.cov(m, fweights=f)            -> cov(m, frequency_weights=f)
-        numpy.cov(m, aweights=a)            -> cov(m, weights=a)
+        numpy.cov(m, fweights=f)            -> cov(m, fweights=f)
+        numpy.cov(m, aweights=a)            -> cov(m, aweights=a)
 
     Unlike ``numpy.cov``, a ``RuntimeWarning`` for non-positive effective
     degrees of freedom is only emitted on the unweighted path. The
@@ -313,12 +313,12 @@ def cov(
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.
     integer_correction = isinstance(correction, int) or correction.is_integer()
-    has_weights = frequency_weights is not None or weights is not None
+    has_weights = fweights is not None or aweights is not None
 
     if m.ndim <= 2 and integer_correction:
         if is_torch_namespace(xp):
-            fw = None if frequency_weights is None else xp.asarray(frequency_weights)
-            aw = None if weights is None else xp.asarray(weights)
+            fw = None if fweights is None else xp.asarray(fweights)
+            aw = None if aweights is None else xp.asarray(aweights)
             return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:
         # its internal `if fact <= 0` check on a lazy 0-D scalar triggers
@@ -333,15 +333,15 @@ def cov(
             return xp.cov(
                 m,
                 ddof=int(correction),
-                fweights=frequency_weights,
-                aweights=weights,
+                fweights=fweights,
+                aweights=aweights,
             )
 
     return _funcs.cov(
         m,
         correction=correction,
-        frequency_weights=frequency_weights,
-        weights=weights,
+        fweights=fweights,
+        aweights=aweights,
         xp=xp,
     )
 

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -315,9 +315,7 @@ def cov(
 
     if m.ndim <= 2 and integer_correction:
         if is_torch_namespace(xp):
-            fw = (
-                None if frequency_weights is None else xp.asarray(frequency_weights)
-            )
+            fw = None if frequency_weights is None else xp.asarray(frequency_weights)
             aw = None if weights is None else xp.asarray(weights)
             return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -166,7 +166,16 @@ def broadcast_shapes(
     return _funcs.broadcast_shapes(*shapes)
 
 
-def cov(m: Array, /, *, xp: ArrayNamespace | None = None) -> Array:
+def cov(
+    m: Array,
+    /,
+    *,
+    axis: int = -1,
+    correction: int | float = 1,
+    frequency_weights: Array | None = None,
+    weights: Array | None = None,
+    xp: ArrayNamespace | None = None,
+) -> Array:
     """
     Estimate a covariance matrix (or a stack of covariance matrices).
 
@@ -177,16 +186,37 @@ def cov(m: Array, /, *, xp: ArrayNamespace | None = None) -> Array:
     :math:`x_i` and :math:`x_j`. The element :math:`C_{ii}` is the variance
     of :math:`x_i`.
 
-    With the exception of supporting batch input, this provides a subset of
-    the functionality of ``numpy.cov``.
+    Extends ``numpy.cov`` with support for batch input and array-api
+    backends. Naming follows the array-api conventions used elsewhere in
+    this library (``axis``, ``correction``) rather than the numpy spellings
+    (``rowvar``, ``bias``, ``ddof``); see Notes for the mapping.
 
     Parameters
     ----------
     m : array
         An array of shape ``(..., N, M)`` whose innermost two dimensions
-        contain *M* observations of *N* variables. That is,
-        each row of `m` represents a variable, and each column a single
-        observation of all those variables.
+        contain *M* observations of *N* variables by default. The axis of
+        observations is controlled by `axis`.
+    axis : int, optional
+        Axis of `m` containing the observations. Default: ``-1`` (the last
+        axis), matching the array-api convention. Use ``axis=-2`` (or ``0``
+        for 2-D input) to treat each column as a variable, which
+        corresponds to ``rowvar=False`` in ``numpy.cov``.
+    correction : int or float, optional
+        Degrees of freedom correction: normalization divides by
+        ``N - correction`` (for unweighted input). Default: ``1``, which
+        gives the unbiased estimate (matches ``numpy.cov`` default of
+        ``bias=False``). Set to ``0`` for the biased estimate (``N``
+        normalization). Corresponds to ``ddof`` in ``numpy.cov`` and to
+        ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
+    frequency_weights : array, optional
+        1-D array of integer frequency weights: the number of times each
+        observation is repeated. Corresponds to ``fweights`` in
+        ``numpy.cov``/``torch.cov``.
+    weights : array, optional
+        1-D array of observation-vector weights (analytic weights). Larger
+        values mark more important observations. Corresponds to
+        ``aweights`` in ``numpy.cov``/``torch.cov``.
     xp : array_namespace, optional
         The standard-compatible namespace for `m`. Default: infer.
 
@@ -195,6 +225,23 @@ def cov(m: Array, /, *, xp: ArrayNamespace | None = None) -> Array:
     array
         An array having shape (..., N, N) whose innermost two dimensions represent
         the covariance matrix of the variables.
+
+    Notes
+    -----
+    Mapping from ``numpy.cov`` to this function::
+
+        numpy.cov(m, rowvar=True)           -> cov(m, axis=-1)   # default
+        numpy.cov(m, rowvar=False)          -> cov(m, axis=-2)
+        numpy.cov(m, bias=True)             -> cov(m, correction=0)
+        numpy.cov(m, ddof=k)                -> cov(m, correction=k)
+        numpy.cov(m, fweights=f)            -> cov(m, frequency_weights=f)
+        numpy.cov(m, aweights=a)            -> cov(m, weights=a)
+
+    Unlike ``numpy.cov``, a ``RuntimeWarning`` for non-positive effective
+    degrees of freedom is only emitted on the unweighted path. The
+    weighted path omits the check so that lazy backends (e.g. Dask) can
+    stay lazy end-to-end; choose ``correction`` and weights such that the
+    effective normalizer is positive.
 
     Examples
     --------
@@ -249,16 +296,57 @@ def cov(m: Array, /, *, xp: ArrayNamespace | None = None) -> Array:
     if xp is None:
         xp = array_namespace(m)
 
-    if (
-        is_numpy_namespace(xp)
-        or is_cupy_namespace(xp)
-        or is_torch_namespace(xp)
-        or is_dask_namespace(xp)
-        or is_jax_namespace(xp)
-    ) and m.ndim <= 2:
-        return xp.cov(m)
+    # Validate axis against m.ndim.
+    ndim = max(m.ndim, 1)
+    if not -ndim <= axis < ndim:
+        msg = f"axis {axis} is out of bounds for array of dimension {m.ndim}"
+        raise IndexError(msg)
 
-    return _funcs.cov(m, xp=xp)
+    # Normalize: observations on the last axis. After this, every backend
+    # sees the same convention and we never need to deal with `rowvar`.
+    if m.ndim >= 2 and axis not in (-1, m.ndim - 1):
+        m = xp.moveaxis(m, axis, -1)
+
+    # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
+    # requires integer `correction`. For non-integer-valued `correction`,
+    # fall through to the generic implementation.
+    integer_correction = isinstance(correction, int) or correction.is_integer()
+    has_weights = frequency_weights is not None or weights is not None
+
+    if m.ndim <= 2 and integer_correction:
+        if is_torch_namespace(xp):
+            device = get_device(m)
+            fw = (
+                None
+                if frequency_weights is None
+                else xp.asarray(frequency_weights, device=device)
+            )
+            aw = None if weights is None else xp.asarray(weights, device=device)
+            return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
+        # `dask.array.cov` forces `.compute()` whenever weights are given:
+        # its internal `if fact <= 0` check on a lazy 0-D scalar triggers
+        # materialization. Route to the generic impl, which is fully lazy
+        # because it only does sum/matmul and skips that scalar check.
+        if (
+            is_numpy_namespace(xp)
+            or is_cupy_namespace(xp)
+            or is_jax_namespace(xp)
+            or (is_dask_namespace(xp) and not has_weights)
+        ):
+            return xp.cov(
+                m,
+                ddof=int(correction),
+                fweights=frequency_weights,
+                aweights=weights,
+            )
+
+    return _funcs.cov(
+        m,
+        correction=correction,
+        frequency_weights=frequency_weights,
+        weights=weights,
+        xp=xp,
+    )
 
 
 def create_diagonal(

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -317,13 +317,10 @@ def cov(
 
     if m.ndim <= 2 and integer_correction:
         if is_torch_namespace(xp):
-            device = get_device(m)
             fw = (
-                None
-                if frequency_weights is None
-                else xp.asarray(frequency_weights, device=device)
+                None if frequency_weights is None else xp.asarray(frequency_weights)
             )
-            aw = None if weights is None else xp.asarray(weights, device=device)
+            aw = None if weights is None else xp.asarray(weights)
             return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:
         # its internal `if fact <= 0` check on a lazy 0-D scalar triggers

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -317,9 +317,7 @@ def cov(
 
     if m.ndim <= 2 and integer_correction:
         if is_torch_namespace(xp):
-            fw = (
-                None if frequency_weights is None else xp.asarray(frequency_weights)
-            )
+            fw = None if frequency_weights is None else xp.asarray(frequency_weights)
             aw = None if weights is None else xp.asarray(weights)
             return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -172,8 +172,8 @@ def cov(
     *,
     axis: int = -1,
     correction: int | float = 1,
-    frequency_weights: Array | None = None,
-    weights: Array | None = None,
+    fweights: Array | None = None,
+    aweights: Array | None = None,
     xp: ArrayNamespace | None = None,
 ) -> Array:
     """
@@ -211,12 +211,12 @@ def cov(
         ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
     fweights : array, optional
         1-D array of integer frequency weights: the number of times each
-        observation is repeated. Corresponds to ``fweights`` in
+        observation is repeated. Same as ``fweights`` in
         ``numpy.cov``/``torch.cov``.
     aweights : array, optional
         1-D array of observation-vector weights (analytic weights). Larger
-        values mark more important observations. Corresponds to
-        ``aweights`` in ``numpy.cov``/``torch.cov``.
+        values mark more important observations. Same as ``aweights`` in
+        ``numpy.cov``/``torch.cov``.
     xp : array_namespace, optional
         The standard-compatible namespace for `m`. Default: infer.
 
@@ -234,8 +234,8 @@ def cov(
         numpy.cov(m, rowvar=False)          -> cov(m, axis=-2)
         numpy.cov(m, bias=True)             -> cov(m, correction=0)
         numpy.cov(m, ddof=k)                -> cov(m, correction=k)
-        numpy.cov(m, fweights=f)            -> cov(m, frequency_weights=f)
-        numpy.cov(m, aweights=a)            -> cov(m, weights=a)
+        numpy.cov(m, fweights=f)            -> cov(m, fweights=f)
+        numpy.cov(m, aweights=a)            -> cov(m, aweights=a)
 
     Unlike ``numpy.cov``, a ``RuntimeWarning`` for non-positive effective
     degrees of freedom is only emitted on the unweighted path. The
@@ -311,12 +311,12 @@ def cov(
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.
     integer_correction = isinstance(correction, int) or correction.is_integer()
-    has_weights = frequency_weights is not None or weights is not None
+    has_weights = fweights is not None or aweights is not None
 
     if m.ndim <= 2 and integer_correction:
         if is_torch_namespace(xp):
-            fw = None if frequency_weights is None else xp.asarray(frequency_weights)
-            aw = None if weights is None else xp.asarray(weights)
+            fw = None if fweights is None else xp.asarray(fweights)
+            aw = None if aweights is None else xp.asarray(aweights)
             return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:
         # its internal `if fact <= 0` check on a lazy 0-D scalar triggers
@@ -331,15 +331,15 @@ def cov(
             return xp.cov(
                 m,
                 ddof=int(correction),
-                fweights=frequency_weights,
-                aweights=weights,
+                fweights=fweights,
+                aweights=aweights,
             )
 
     return _funcs.cov(
         m,
         correction=correction,
-        frequency_weights=frequency_weights,
-        weights=weights,
+        fweights=fweights,
+        aweights=aweights,
         xp=xp,
     )
 

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -212,11 +212,11 @@ def cov(
         ``bias=False``). Set to ``0`` for the biased estimate (``N``
         normalization). Corresponds to ``ddof`` in ``numpy.cov`` and to
         ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
-    frequency_weights : array, optional
+    fweights : array, optional
         1-D array of integer frequency weights: the number of times each
         observation is repeated. Corresponds to ``fweights`` in
         ``numpy.cov``/``torch.cov``.
-    weights : array, optional
+    aweights : array, optional
         1-D array of observation-vector weights (analytic weights). Larger
         values mark more important observations. Corresponds to
         ``aweights`` in ``numpy.cov``/``torch.cov``.

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -185,11 +185,11 @@ def cov(
     Covariance indicates the level to which two variables vary together.
     If we examine *N*-dimensional samples, :math:`X = [x_1, x_2, ... x_N]^T`,
     each with *M* observations, then element :math:`C_{ij}` of the
-    :math:`N \times N` covariance matrix is the covariance of
+    :math:`N \\times N` covariance matrix is the covariance of
     :math:`x_i` and :math:`x_j`. The element :math:`C_{ii}` is the variance
     of :math:`x_i`.
 
-    Extends ``numpy.cov`` with support for batch input.
+    Extends :func:`numpy.cov` with support for batch input.
     Naming follows the array API conventions used elsewhere in
     this library (``axis``, ``correction``) rather than the NumPy spellings
     (``rowvar``, ``bias``, ``ddof``); see Notes for the mapping.
@@ -202,9 +202,9 @@ def cov(
         observations is controlled by `axis`.
     axis : int, optional
         Axis of `m` containing the observations. Default: ``-1`` (the last
-        axis), matching the array-api convention. Use ``axis=-2`` (or ``0``
+        axis), matching the array API convention. Use ``axis=-2`` (or ``0``
         for 2-D input) to treat each column as a variable, which
-        corresponds to ``rowvar=False`` in ``numpy.cov``.
+        corresponds to ``rowvar=False`` in :func:`numpy.cov`.
     correction : int or float, optional
         Degrees of freedom correction: normalization divides by
         ``N - correction`` (for unweighted input). Default: ``1``, which
@@ -233,7 +233,7 @@ def cov(
     Returns
     -------
     array
-        An array having shape (..., N, N) whose innermost two dimensions represent
+        An array having shape ``(..., N, N)`` whose innermost two dimensions represent
         the covariance matrix of the variables.
 
     Notes

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -296,7 +296,7 @@ def cov(
     """
 
     if xp is None:
-        xp = array_namespace(m)
+        xp = array_namespace(m, fweights, aweights)
 
     # Validate axis against m.ndim.
     ndim = max(m.ndim, 1)
@@ -320,9 +320,7 @@ def cov(
             msg = f"`{name}` must be 1-D, got ndim={w.ndim}"
             raise ValueError(msg)
         if w.shape[0] != n_obs:
-            msg = (
-                f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
-            )
+            msg = f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
             raise ValueError(msg)
 
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -307,6 +307,22 @@ def cov(
     if m.ndim >= 2 and axis not in (-1, m.ndim - 1):
         m = xp.moveaxis(m, axis, -1)
 
+    # Validate weight shapes (eager metadata, lazy-safe). Value-based
+    # checks (non-negative, integer dtype) are intentionally skipped so
+    # lazy backends don't trigger compute -- same tradeoff as dask.cov.
+    n_obs = m.shape[-1]
+    for name, w in (("fweights", fweights), ("aweights", aweights)):
+        if w is None:
+            continue
+        if w.ndim != 1:
+            msg = f"`{name}` must be 1-D, got ndim={w.ndim}"
+            raise ValueError(msg)
+        if w.shape[0] != n_obs:
+            msg = (
+                f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
+            )
+            raise ValueError(msg)
+
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -209,11 +209,11 @@ def cov(
         ``bias=False``). Set to ``0`` for the biased estimate (``N``
         normalization). Corresponds to ``ddof`` in ``numpy.cov`` and to
         ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
-    frequency_weights : array, optional
+    fweights : array, optional
         1-D array of integer frequency weights: the number of times each
         observation is repeated. Corresponds to ``fweights`` in
         ``numpy.cov``/``torch.cov``.
-    weights : array, optional
+    aweights : array, optional
         1-D array of observation-vector weights (analytic weights). Larger
         values mark more important observations. Corresponds to
         ``aweights`` in ``numpy.cov``/``torch.cov``.

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -212,6 +212,13 @@ def cov(
         ``bias=False``). Set to ``0`` for the biased estimate (``N``
         normalization). Corresponds to ``ddof`` in ``numpy.cov`` and to
         ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
+        Non-integer values are allowed for advanced use cases: the
+        unbiased correction for weighted observations depends on the
+        sum and dispersion of the weights and is generally not an
+        integer, and autocorrelated data may also require a fractional
+        correction. Non-integer ``correction`` routes through the
+        generic implementation because ``numpy.cov``'s ``ddof`` and
+        ``torch.cov``'s ``correction`` both require integers.
     fweights : array, optional
         1-D array of integer frequency weights: the number of times each
         observation is repeated. Same as ``fweights`` in

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -209,6 +209,13 @@ def cov(
         ``bias=False``). Set to ``0`` for the biased estimate (``N``
         normalization). Corresponds to ``ddof`` in ``numpy.cov`` and to
         ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
+        Non-integer values are allowed for advanced use cases: the
+        unbiased correction for weighted observations depends on the
+        sum and dispersion of the weights and is generally not an
+        integer, and autocorrelated data may also require a fractional
+        correction. Non-integer ``correction`` routes through the
+        generic implementation because ``numpy.cov``'s ``ddof`` and
+        ``torch.cov``'s ``correction`` both require integers.
     fweights : array, optional
         1-D array of integer frequency weights: the number of times each
         observation is repeated. Same as ``fweights`` in

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -309,20 +309,6 @@ def cov(
     if m.ndim >= 2 and axis not in (-1, m.ndim - 1):
         m = xp.moveaxis(m, axis, -1)
 
-    # Validate weight shapes (eager metadata, lazy-safe). Value-based
-    # checks (non-negative, integer dtype) are intentionally skipped so
-    # lazy backends don't trigger compute -- same tradeoff as dask.cov.
-    n_obs = m.shape[-1]
-    for name, w in (("fweights", fweights), ("aweights", aweights)):
-        if w is None:
-            continue
-        if w.ndim != 1:
-            msg = f"`{name}` must be 1-D, got ndim={w.ndim}"
-            raise ValueError(msg)
-        if w.shape[0] != n_obs:
-            msg = f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
-            raise ValueError(msg)
-
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -208,25 +208,26 @@ def cov(
     correction : int or float, optional
         Degrees of freedom correction: normalization divides by
         ``N - correction`` (for unweighted input). Default: ``1``, which
-        gives the unbiased estimate (matches ``numpy.cov`` default of
+        gives the unbiased estimate (matches :func:`numpy.cov` default of
         ``bias=False``). Set to ``0`` for the biased estimate (``N``
-        normalization). Corresponds to ``ddof`` in ``numpy.cov`` and to
-        ``correction`` in ``numpy.var``/``std`` and ``torch.cov``.
+        normalization). Corresponds to ``ddof`` in :func:`numpy.cov` and to
+        ``correction`` in :func:`numpy.var`/:func:`numpy.std` and
+        :func:`torch.cov`.
         Non-integer values are allowed for advanced use cases: the
         unbiased correction for weighted observations depends on the
         sum and dispersion of the weights and is generally not an
         integer, and autocorrelated data may also require a fractional
         correction. Non-integer ``correction`` routes through the
-        generic implementation because ``numpy.cov``'s ``ddof`` and
-        ``torch.cov``'s ``correction`` both require integers.
+        generic implementation because :func:`numpy.cov`'s ``ddof`` and
+        :func:`torch.cov`'s ``correction`` both require integers.
     fweights : array, optional
         1-D array of integer frequency weights: the number of times each
         observation is repeated. Same as ``fweights`` in
-        ``numpy.cov``/``torch.cov``.
+        :func:`numpy.cov`/:func:`torch.cov`.
     aweights : array, optional
         1-D array of observation-vector weights (analytic weights). Larger
         values mark more important observations. Same as ``aweights`` in
-        ``numpy.cov``/``torch.cov``.
+        :func:`numpy.cov`/:func:`torch.cov`.
     xp : array_namespace, optional
         The standard-compatible namespace for `m`. Default: infer.
 
@@ -238,7 +239,7 @@ def cov(
 
     Notes
     -----
-    Mapping from ``numpy.cov`` to this function::
+    Mapping from :func:`numpy.cov` to this function::
 
         numpy.cov(m, rowvar=True)           -> cov(m, axis=-1)   # default
         numpy.cov(m, rowvar=False)          -> cov(m, axis=-2)
@@ -300,6 +301,30 @@ def cov(
             [ -4.286     ,   2.14413333]],
            [[ 46.84      , -17.144     ],
             [-17.144     ,   8.57653333]]], dtype=array_api_strict.float64)
+
+    The normalization can be adjusted with `correction`, and observations
+    can be weighted with integer frequencies `fweights` or importance
+    weights `aweights`:
+
+    >>> x = xp.asarray([0., 1., 2., 3., 4.])
+    >>> xpx.cov(x, xp=xp)  # unbiased variance: divide by N - 1
+    Array(2.5, dtype=array_api_strict.float64)
+    >>> xpx.cov(x, correction=0, xp=xp)  # biased variance: divide by N
+    Array(2., dtype=array_api_strict.float64)
+
+    Giving the two extreme observations frequency 2 via `fweights` is
+    equivalent to repeating them in `x`:
+
+    >>> xpx.cov(x, fweights=xp.asarray([2, 1, 1, 1, 2]), xp=xp)
+    Array(3., dtype=array_api_strict.float64)
+    >>> xpx.cov(xp.asarray([0., 0., 1., 2., 3., 4., 4.]), xp=xp)
+    Array(3., dtype=array_api_strict.float64)
+
+    `aweights` instead adjusts the relative importance of observations,
+    here down-weighting the two extremes:
+
+    >>> xpx.cov(x, aweights=xp.asarray([0.5, 1., 1., 1., 0.5]), xp=xp)
+    Array(1.92, dtype=array_api_strict.float64)
     """
 
     if xp is None:
@@ -319,14 +344,17 @@ def cov(
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`
     # requires integer `correction`. For non-integer-valued `correction`,
     # fall through to the generic implementation.
-    integer_correction = isinstance(correction, int) or correction.is_integer()
+    integer_correction = float(correction).is_integer()
     has_weights = fweights is not None or aweights is not None
 
     if m.ndim <= 2 and integer_correction:
+        # Not just for static typing: `correction` may be an integer-valued
+        # float such as 1.0, which `torch.cov` rejects at runtime.
+        int_correction = int(correction)
         if is_torch_namespace(xp):
             fw = None if fweights is None else xp.asarray(fweights)
             aw = None if aweights is None else xp.asarray(aweights)
-            return xp.cov(m, correction=int(correction), fweights=fw, aweights=aw)
+            return xp.cov(m, correction=int_correction, fweights=fw, aweights=aw)
         # `dask.array.cov` forces `.compute()` whenever weights are given:
         # its internal `if fact <= 0` check on a lazy 0-D scalar triggers
         # materialization. Route to the generic impl, which is fully lazy
@@ -339,7 +367,7 @@ def cov(
         ):
             return xp.cov(
                 m,
-                ddof=int(correction),
+                ddof=int_correction,
                 fweights=fweights,
                 aweights=aweights,
             )

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -189,9 +189,9 @@ def cov(
     :math:`x_i` and :math:`x_j`. The element :math:`C_{ii}` is the variance
     of :math:`x_i`.
 
-    Extends ``numpy.cov`` with support for batch input and array-api
-    backends. Naming follows the array-api conventions used elsewhere in
-    this library (``axis``, ``correction``) rather than the numpy spellings
+    Extends ``numpy.cov`` with support for batch input.
+    Naming follows the array API conventions used elsewhere in
+    this library (``axis``, ``correction``) rather than the NumPy spellings
     (``rowvar``, ``bias``, ``ddof``); see Notes for the mapping.
 
     Parameters
@@ -247,11 +247,11 @@ def cov(
         numpy.cov(m, fweights=f)            -> cov(m, fweights=f)
         numpy.cov(m, aweights=a)            -> cov(m, aweights=a)
 
-    Unlike ``numpy.cov``, a ``RuntimeWarning`` for non-positive effective
-    degrees of freedom is only emitted on the unweighted path. The
-    weighted path omits the check so that lazy backends (e.g. Dask) can
-    stay lazy end-to-end; choose ``correction`` and weights such that the
-    effective normalizer is positive.
+    A ``RuntimeWarning`` is emitted for non-positive effective degrees of
+    freedom when the effective normalizer can be checked without materializing
+    a lazy array. When the normalizer itself is lazy (e.g. for weighted Dask
+    inputs), this check is skipped; choose ``correction`` and weights such that
+    it is positive.
 
     Examples
     --------

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -294,7 +294,7 @@ def cov(
     """
 
     if xp is None:
-        xp = array_namespace(m)
+        xp = array_namespace(m, fweights, aweights)
 
     # Validate axis against m.ndim.
     ndim = max(m.ndim, 1)
@@ -318,9 +318,7 @@ def cov(
             msg = f"`{name}` must be 1-D, got ndim={w.ndim}"
             raise ValueError(msg)
         if w.shape[0] != n_obs:
-            msg = (
-                f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
-            )
+            msg = f"`{name}` has length {w.shape[0]} but `m` has {n_obs} observations"
             raise ValueError(msg)
 
     # `numpy.cov` (and cupy/dask/jax) require integer `ddof`; `torch.cov`

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -299,16 +299,15 @@ def cov(
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
-    device = _compat.device(m)
     fw = (
         None
         if frequency_weights is None
-        else xp.astype(xp.asarray(frequency_weights, device=device), dtype)
+        else xp.astype(xp.asarray(frequency_weights), dtype)
     )
     aw = (
         None
         if weights is None
-        else xp.astype(xp.asarray(weights, device=device), dtype)
+        else xp.astype(xp.asarray(weights), dtype)
     )
     if fw is None and aw is None:
         w = None

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -286,8 +286,8 @@ def cov(
     /,
     *,
     correction: int | float = 1,
-    frequency_weights: Array | None = None,
-    weights: Array | None = None,
+    fweights: Array | None = None,
+    aweights: Array | None = None,
     xp: ModuleType,
 ) -> Array:  # numpydoc ignore=PR01,RT01
     """See docstring in array_api_extra._delegation."""
@@ -300,9 +300,11 @@ def cov(
     m = xp.astype(m, dtype)
 
     fw = None
-    if frequency_weights is not None:
-        fw = xp.astype(xp.asarray(frequency_weights), dtype)
-    aw = None if weights is None else xp.astype(xp.asarray(weights), dtype)
+    if fweights is not None:
+        fw = xp.astype(xp.asarray(fweights), dtype)
+    aw = None
+    if aweights is not None:
+        aw = xp.astype(xp.asarray(aweights), dtype)
     if fw is None and aw is None:
         w = None
     elif fw is None:

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -353,7 +353,7 @@ def cov(
     m_cT = xp.matrix_transpose(m_c)
     if xp.isdtype(m_cT.dtype, "complex floating"):
         m_cT = xp.conj(m_cT)
-    c = (m_w @ m_cT) / fact
+    c = m_w @ m_cT / fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
 

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -336,7 +336,7 @@ def cov(
     m_cT = xp.matrix_transpose(m_c)
     if xp.isdtype(m_cT.dtype, "complex floating"):
         m_cT = xp.conj(m_cT)
-    c = xp.matmul(m_w, m_cT) / fact
+    c = (m_w @ m_cT) / fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
 

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -304,11 +304,7 @@ def cov(
         if frequency_weights is None
         else xp.astype(xp.asarray(frequency_weights), dtype)
     )
-    aw = (
-        None
-        if weights is None
-        else xp.astype(xp.asarray(weights), dtype)
-    )
+    aw = None if weights is None else xp.astype(xp.asarray(weights), dtype)
     if fw is None and aw is None:
         w = None
     elif fw is None:

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -299,6 +299,23 @@ def cov(
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
+    # Validate weight shapes (eager metadata, lazy-safe). Native backends
+    # validate themselves; this covers the generic path (array-api-strict,
+    # sparse, and the dask+weights fallback where the native check is
+    # bypassed to preserve laziness).
+    n_obs = m.shape[-1]
+    for name, w_in in (("fweights", fweights), ("aweights", aweights)):
+        if w_in is None:
+            continue
+        if w_in.ndim != 1:
+            msg = f"`{name}` must be 1-D, got ndim={w_in.ndim}"
+            raise ValueError(msg)
+        if w_in.shape[0] != n_obs:
+            msg = (
+                f"`{name}` has length {w_in.shape[0]} but `m` has {n_obs} observations"
+            )
+            raise ValueError(msg)
+
     fw = None
     if fweights is not None:
         fw = xp.astype(xp.asarray(fweights), dtype)

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -281,9 +281,17 @@ def broadcast_shapes(*shapes: tuple[float | None, ...]) -> tuple[int | None, ...
     return tuple(out)
 
 
-def cov(m: Array, /, *, xp: ModuleType) -> Array:  # numpydoc ignore=PR01,RT01
+def cov(
+    m: Array,
+    /,
+    *,
+    correction: int | float = 1,
+    frequency_weights: Array | None = None,
+    weights: Array | None = None,
+    xp: ModuleType,
+) -> Array:  # numpydoc ignore=PR01,RT01
     """See docstring in array_api_extra._delegation."""
-    m = xp.asarray(m, copy=True)
+    m = xp.asarray(m)
     dtype = (
         xp.float64 if xp.isdtype(m.dtype, "integral") else xp.result_type(m, xp.float64)
     )
@@ -291,21 +299,49 @@ def cov(m: Array, /, *, xp: ModuleType) -> Array:  # numpydoc ignore=PR01,RT01
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
-    avg = xp.mean(m, axis=-1, keepdims=True)
+    device = _compat.device(m)
+    fw = (
+        None
+        if frequency_weights is None
+        else xp.astype(xp.asarray(frequency_weights, device=device), dtype)
+    )
+    aw = (
+        None
+        if weights is None
+        else xp.astype(xp.asarray(weights, device=device), dtype)
+    )
+    if fw is None and aw is None:
+        w = None
+    elif fw is None:
+        w = aw
+    elif aw is None:
+        w = fw
+    else:
+        w = fw * aw
 
     m_shape = eager_shape(m)
-    fact = m_shape[-1] - 1
+    if w is None:
+        avg = xp.mean(m, axis=-1, keepdims=True)
+        fact = m_shape[-1] - correction
+        if fact <= 0:
+            warnings.warn(
+                "Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2
+            )
+            fact = 0
+    else:
+        v1 = xp.sum(w, axis=-1)
+        avg = xp.sum(m * w, axis=-1, keepdims=True) / v1
+        if aw is None:
+            fact = v1 - correction
+        else:
+            fact = v1 - correction * xp.sum(w * aw, axis=-1) / v1
 
-    if fact <= 0:
-        warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2)
-        fact = 0
-
-    m -= avg
-    m_transpose = xp.matrix_transpose(m)
-    if xp.isdtype(m_transpose.dtype, "complex floating"):
-        m_transpose = xp.conj(m_transpose)
-    c = xp.matmul(m, m_transpose)
-    c /= fact
+    m_c = m - avg
+    m_w = m_c if w is None else m_c * w
+    m_cT = xp.matrix_transpose(m_c)
+    if xp.isdtype(m_cT.dtype, "complex floating"):
+        m_cT = xp.conj(m_cT)
+    c = xp.matmul(m_w, m_cT) / fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
 

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -299,11 +299,9 @@ def cov(
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
-    fw = (
-        None
-        if frequency_weights is None
-        else xp.astype(xp.asarray(frequency_weights), dtype)
-    )
+    fw = None
+    if frequency_weights is not None:
+        fw = xp.astype(xp.asarray(frequency_weights), dtype)
     aw = None if weights is None else xp.astype(xp.asarray(weights), dtype)
     if fw is None and aw is None:
         w = None

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -281,7 +281,8 @@ def cov(
     )
 
     m = atleast_nd(m, ndim=2, xp=xp)
-    m = xp.astype(m, dtype)
+    # Preserve the historical no-alias guarantee even when the dtype already matches.
+    m = xp.astype(m, dtype, copy=True)
 
     # Validate weight shapes (eager metadata, lazy-safe). Native backends
     # validate themselves; this covers the generic path (array-api-strict,
@@ -294,9 +295,16 @@ def cov(
         if w_in.ndim != 1:
             msg = f"`{name}` must be 1-D, got ndim={w_in.ndim}"
             raise ValueError(msg)
-        if w_in.shape[0] != n_obs:
+        weight_length = w_in.shape[0]
+        if (
+            weight_length is not None
+            and n_obs is not None
+            and not math.isnan(weight_length)
+            and not math.isnan(n_obs)
+            and weight_length != n_obs
+        ):
             msg = (
-                f"`{name}` has length {w_in.shape[0]} but `m` has {n_obs} observations"
+                f"`{name}` has length {weight_length} but `m` has {n_obs} observations"
             )
             raise ValueError(msg)
 
@@ -315,15 +323,9 @@ def cov(
     else:
         w = fw * aw
 
-    m_shape = eager_shape(m)
     if w is None:
         avg = xp.mean(m, axis=-1, keepdims=True)
-        fact = m_shape[-1] - correction
-        if fact <= 0:
-            warnings.warn(
-                "Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2
-            )
-            fact = 0
+        fact = eager_shape(m, axis=-1)[0] - correction
     else:
         v1 = xp.sum(w, axis=-1)
         avg = xp.sum(m * w, axis=-1, keepdims=True) / v1
@@ -331,6 +333,25 @@ def cov(
             fact = v1 - correction
         else:
             fact = v1 - correction * xp.sum(w * aw, axis=-1) / v1
+
+    if not _compat.is_lazy_array(fact):
+        # Weights are cast to `dtype`, so a complex input produces a complex
+        # normalizer with a zero imaginary part. Complex ordering is undefined;
+        # compare its real component instead.
+        if w is not None:
+            fact_array = cast(Array, fact)
+            fact_to_check = (
+                xp.real(fact_array)
+                if xp.isdtype(fact_array.dtype, "complex floating")
+                else fact_array
+            )
+        else:
+            fact_to_check = fact
+        if fact_to_check <= 0:
+            warnings.warn(
+                "Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2
+            )
+            fact = 0
 
     m_c = m - avg
     m_w = m_c if w is None else m_c * w

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -268,8 +268,8 @@ def cov(
     /,
     *,
     correction: int | float = 1,
-    frequency_weights: Array | None = None,
-    weights: Array | None = None,
+    fweights: Array | None = None,
+    aweights: Array | None = None,
     xp: ArrayNamespace,
 ) -> Array:  # numpydoc ignore=PR01,RT01
     """See docstring in array_api_extra._delegation."""
@@ -282,9 +282,11 @@ def cov(
     m = xp.astype(m, dtype)
 
     fw = None
-    if frequency_weights is not None:
-        fw = xp.astype(xp.asarray(frequency_weights), dtype)
-    aw = None if weights is None else xp.astype(xp.asarray(weights), dtype)
+    if fweights is not None:
+        fw = xp.astype(xp.asarray(fweights), dtype)
+    aw = None
+    if aweights is not None:
+        aw = xp.astype(xp.asarray(aweights), dtype)
     if fw is None and aw is None:
         w = None
     elif fw is None:

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -281,6 +281,23 @@ def cov(
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
+    # Validate weight shapes (eager metadata, lazy-safe). Native backends
+    # validate themselves; this covers the generic path (array-api-strict,
+    # sparse, and the dask+weights fallback where the native check is
+    # bypassed to preserve laziness).
+    n_obs = m.shape[-1]
+    for name, w_in in (("fweights", fweights), ("aweights", aweights)):
+        if w_in is None:
+            continue
+        if w_in.ndim != 1:
+            msg = f"`{name}` must be 1-D, got ndim={w_in.ndim}"
+            raise ValueError(msg)
+        if w_in.shape[0] != n_obs:
+            msg = (
+                f"`{name}` has length {w_in.shape[0]} but `m` has {n_obs} observations"
+            )
+            raise ValueError(msg)
+
     fw = None
     if fweights is not None:
         fw = xp.astype(xp.asarray(fweights), dtype)

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -260,9 +260,17 @@ def broadcast_shapes(  # numpydoc ignore=PR01,RT01
     return tuple(out)
 
 
-def cov(m: Array, /, *, xp: ArrayNamespace) -> Array:  # numpydoc ignore=PR01,RT01
+def cov(
+    m: Array,
+    /,
+    *,
+    correction: int | float = 1,
+    frequency_weights: Array | None = None,
+    weights: Array | None = None,
+    xp: ArrayNamespace,
+) -> Array:  # numpydoc ignore=PR01,RT01
     """See docstring in array_api_extra._delegation."""
-    m = xp.asarray(m, copy=True)
+    m = xp.asarray(m)
     dtype = (
         xp.float64 if xp.isdtype(m.dtype, "integral") else xp.result_type(m, xp.float64)
     )
@@ -270,21 +278,49 @@ def cov(m: Array, /, *, xp: ArrayNamespace) -> Array:  # numpydoc ignore=PR01,RT
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
-    avg = xp.mean(m, axis=-1, keepdims=True)
+    device = _compat.device(m)
+    fw = (
+        None
+        if frequency_weights is None
+        else xp.astype(xp.asarray(frequency_weights, device=device), dtype)
+    )
+    aw = (
+        None
+        if weights is None
+        else xp.astype(xp.asarray(weights, device=device), dtype)
+    )
+    if fw is None and aw is None:
+        w = None
+    elif fw is None:
+        w = aw
+    elif aw is None:
+        w = fw
+    else:
+        w = fw * aw
 
     m_shape = eager_shape(m)
-    fact = m_shape[-1] - 1
+    if w is None:
+        avg = xp.mean(m, axis=-1, keepdims=True)
+        fact = m_shape[-1] - correction
+        if fact <= 0:
+            warnings.warn(
+                "Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2
+            )
+            fact = 0
+    else:
+        v1 = xp.sum(w, axis=-1)
+        avg = xp.sum(m * w, axis=-1, keepdims=True) / v1
+        if aw is None:
+            fact = v1 - correction
+        else:
+            fact = v1 - correction * xp.sum(w * aw, axis=-1) / v1
 
-    if fact <= 0:
-        warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2)
-        fact = 0
-
-    m -= avg
-    m_transpose = xp.matrix_transpose(m)
-    if xp.isdtype(m_transpose.dtype, "complex floating"):
-        m_transpose = xp.conj(m_transpose)
-    c = xp.matmul(m, m_transpose)
-    c /= fact
+    m_c = m - avg
+    m_w = m_c if w is None else m_c * w
+    m_cT = xp.matrix_transpose(m_c)
+    if xp.isdtype(m_cT.dtype, "complex floating"):
+        m_cT = xp.conj(m_cT)
+    c = xp.matmul(m_w, m_cT) / fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
 

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -278,7 +278,8 @@ def cov(
     )
 
     m = atleast_nd(m, ndim=2, xp=xp)
-    m = xp.astype(m, dtype)
+    # Preserve the historical no-alias guarantee even when the dtype already matches.
+    m = xp.astype(m, dtype, copy=True)
 
     # Validate weight shapes (eager metadata, lazy-safe). Native backends
     # validate themselves; this covers the generic path (array-api-strict,
@@ -291,9 +292,16 @@ def cov(
         if w_in.ndim != 1:
             msg = f"`{name}` must be 1-D, got ndim={w_in.ndim}"
             raise ValueError(msg)
-        if w_in.shape[0] != n_obs:
+        weight_length = w_in.shape[0]
+        if (
+            weight_length is not None
+            and n_obs is not None
+            and not math.isnan(weight_length)
+            and not math.isnan(n_obs)
+            and weight_length != n_obs
+        ):
             msg = (
-                f"`{name}` has length {w_in.shape[0]} but `m` has {n_obs} observations"
+                f"`{name}` has length {weight_length} but `m` has {n_obs} observations"
             )
             raise ValueError(msg)
 
@@ -312,15 +320,9 @@ def cov(
     else:
         w = fw * aw
 
-    m_shape = eager_shape(m)
     if w is None:
         avg = xp.mean(m, axis=-1, keepdims=True)
-        fact = m_shape[-1] - correction
-        if fact <= 0:
-            warnings.warn(
-                "Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2
-            )
-            fact = 0
+        fact = eager_shape(m, axis=-1)[0] - correction
     else:
         v1 = xp.sum(w, axis=-1)
         avg = xp.sum(m * w, axis=-1, keepdims=True) / v1
@@ -328,6 +330,25 @@ def cov(
             fact = v1 - correction
         else:
             fact = v1 - correction * xp.sum(w * aw, axis=-1) / v1
+
+    if not _compat.is_lazy_array(fact):
+        # Weights are cast to `dtype`, so a complex input produces a complex
+        # normalizer with a zero imaginary part. Complex ordering is undefined;
+        # compare its real component instead.
+        if w is not None:
+            fact_array = cast(Array, fact)
+            fact_to_check = (
+                xp.real(fact_array)
+                if xp.isdtype(fact_array.dtype, "complex floating")
+                else fact_array
+            )
+        else:
+            fact_to_check = fact
+        if fact_to_check <= 0:
+            warnings.warn(
+                "Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2
+            )
+            fact = 0
 
     m_c = m - avg
     m_w = m_c if w is None else m_c * w

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -315,7 +315,7 @@ def cov(
     m_cT = xp.matrix_transpose(m_c)
     if xp.isdtype(m_cT.dtype, "complex floating"):
         m_cT = xp.conj(m_cT)
-    c = xp.matmul(m_w, m_cT) / fact
+    c = (m_w @ m_cT) / fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
 

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -293,6 +293,8 @@ def cov(
             msg = f"`{name}` must be 1-D, got ndim={w_in.ndim}"
             raise ValueError(msg)
         weight_length = w_in.shape[0]
+        # Unknown dims are `None` per the standard; Dask non-standardly
+        # reports them as NaN, hence the `isnan` checks below.
         if (
             weight_length is not None
             and n_obs is not None

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -278,6 +278,23 @@ def cov(
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
+    # Validate weight shapes (eager metadata, lazy-safe). Native backends
+    # validate themselves; this covers the generic path (array-api-strict,
+    # sparse, and the dask+weights fallback where the native check is
+    # bypassed to preserve laziness).
+    n_obs = m.shape[-1]
+    for name, w_in in (("fweights", fweights), ("aweights", aweights)):
+        if w_in is None:
+            continue
+        if w_in.ndim != 1:
+            msg = f"`{name}` must be 1-D, got ndim={w_in.ndim}"
+            raise ValueError(msg)
+        if w_in.shape[0] != n_obs:
+            msg = (
+                f"`{name}` has length {w_in.shape[0]} but `m` has {n_obs} observations"
+            )
+            raise ValueError(msg)
+
     fw = None
     if fweights is not None:
         fw = xp.astype(xp.asarray(fweights), dtype)

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -267,7 +267,7 @@ def cov(
     m: Array,
     /,
     *,
-    correction: int | float = 1,
+    correction: float = 1,
     fweights: Array | None = None,
     aweights: Array | None = None,
     xp: ArrayNamespace,

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -278,11 +278,9 @@ def cov(
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
-    fw = (
-        None
-        if frequency_weights is None
-        else xp.astype(xp.asarray(frequency_weights), dtype)
-    )
+    fw = None
+    if frequency_weights is not None:
+        fw = xp.astype(xp.asarray(frequency_weights), dtype)
     aw = None if weights is None else xp.astype(xp.asarray(weights), dtype)
     if fw is None and aw is None:
         w = None

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -278,16 +278,15 @@ def cov(
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
-    device = _compat.device(m)
     fw = (
         None
         if frequency_weights is None
-        else xp.astype(xp.asarray(frequency_weights, device=device), dtype)
+        else xp.astype(xp.asarray(frequency_weights), dtype)
     )
     aw = (
         None
         if weights is None
-        else xp.astype(xp.asarray(weights, device=device), dtype)
+        else xp.astype(xp.asarray(weights), dtype)
     )
     if fw is None and aw is None:
         w = None

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -284,10 +284,7 @@ def cov(
     # Preserve the historical no-alias guarantee even when the dtype already matches.
     m = xp.astype(m, dtype, copy=True)
 
-    # Validate weight shapes (eager metadata, lazy-safe). Native backends
-    # validate themselves; this covers the generic path (array-api-strict,
-    # sparse, and the dask+weights fallback where the native check is
-    # bypassed to preserve laziness).
+    # Validate weight shapes (eager metadata, lazy-safe).
     n_obs = m.shape[-1]
     for name, w_in in (("fweights", fweights), ("aweights", aweights)):
         if w_in is None:

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -332,7 +332,7 @@ def cov(
     m_cT = xp.matrix_transpose(m_c)
     if xp.isdtype(m_cT.dtype, "complex floating"):
         m_cT = xp.conj(m_cT)
-    c = (m_w @ m_cT) / fact
+    c = m_w @ m_cT / fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
 

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -281,16 +281,15 @@ def cov(
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
-    device = _compat.device(m)
     fw = (
         None
         if frequency_weights is None
-        else xp.astype(xp.asarray(frequency_weights, device=device), dtype)
+        else xp.astype(xp.asarray(frequency_weights), dtype)
     )
     aw = (
         None
         if weights is None
-        else xp.astype(xp.asarray(weights, device=device), dtype)
+        else xp.astype(xp.asarray(weights), dtype)
     )
     if fw is None and aw is None:
         w = None

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -335,7 +335,7 @@ def cov(
     m_cT = xp.matrix_transpose(m_c)
     if xp.isdtype(m_cT.dtype, "complex floating"):
         m_cT = xp.conj(m_cT)
-    c = (m_w @ m_cT) / fact
+    c = m_w @ m_cT / fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
 

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -318,7 +318,7 @@ def cov(
     m_cT = xp.matrix_transpose(m_c)
     if xp.isdtype(m_cT.dtype, "complex floating"):
         m_cT = xp.conj(m_cT)
-    c = xp.matmul(m_w, m_cT) / fact
+    c = (m_w @ m_cT) / fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
 

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -265,8 +265,8 @@ def cov(
     /,
     *,
     correction: int | float = 1,
-    frequency_weights: Array | None = None,
-    weights: Array | None = None,
+    fweights: Array | None = None,
+    aweights: Array | None = None,
     xp: ArrayNamespace,
 ) -> Array:  # numpydoc ignore=PR01,RT01
     """See docstring in array_api_extra._delegation."""
@@ -279,9 +279,11 @@ def cov(
     m = xp.astype(m, dtype)
 
     fw = None
-    if frequency_weights is not None:
-        fw = xp.astype(xp.asarray(frequency_weights), dtype)
-    aw = None if weights is None else xp.astype(xp.asarray(weights), dtype)
+    if fweights is not None:
+        fw = xp.astype(xp.asarray(fweights), dtype)
+    aw = None
+    if aweights is not None:
+        aw = xp.astype(xp.asarray(aweights), dtype)
     if fw is None and aw is None:
         w = None
     elif fw is None:

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -273,7 +273,9 @@ def cov(
     xp: ArrayNamespace,
 ) -> Array:  # numpydoc ignore=PR01,RT01
     """See docstring in array_api_extra._delegation."""
-    m = xp.asarray(m)
+    # NB: no `xp.asarray(m)` here. The delegation layer already guarantees `m`
+    # is an array (it calls `array_namespace(m)` and reads `m.ndim`), and on
+    # torch `xp.asarray` detaches gradients and mutates the caller's tensor.
     dtype = (
         xp.float64 if xp.isdtype(m.dtype, "integral") else xp.result_type(m, xp.float64)
     )

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -286,11 +286,7 @@ def cov(
         if frequency_weights is None
         else xp.astype(xp.asarray(frequency_weights), dtype)
     )
-    aw = (
-        None
-        if weights is None
-        else xp.astype(xp.asarray(weights), dtype)
-    )
+    aw = None if weights is None else xp.astype(xp.asarray(weights), dtype)
     if fw is None and aw is None:
         w = None
     elif fw is None:

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -270,7 +270,9 @@ def cov(
     xp: ArrayNamespace,
 ) -> Array:  # numpydoc ignore=PR01,RT01
     """See docstring in array_api_extra._delegation."""
-    m = xp.asarray(m)
+    # NB: no `xp.asarray(m)` here. The delegation layer already guarantees `m`
+    # is an array (it calls `array_namespace(m)` and reads `m.ndim`), and on
+    # torch `xp.asarray` detaches gradients and mutates the caller's tensor.
     dtype = (
         xp.float64 if xp.isdtype(m.dtype, "integral") else xp.result_type(m, xp.float64)
     )

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -283,11 +283,7 @@ def cov(
         if frequency_weights is None
         else xp.astype(xp.asarray(frequency_weights), dtype)
     )
-    aw = (
-        None
-        if weights is None
-        else xp.astype(xp.asarray(weights), dtype)
-    )
+    aw = None if weights is None else xp.astype(xp.asarray(weights), dtype)
     if fw is None and aw is None:
         w = None
     elif fw is None:

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -281,11 +281,9 @@ def cov(
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
-    fw = (
-        None
-        if frequency_weights is None
-        else xp.astype(xp.asarray(frequency_weights), dtype)
-    )
+    fw = None
+    if frequency_weights is not None:
+        fw = xp.astype(xp.asarray(frequency_weights), dtype)
     aw = None if weights is None else xp.astype(xp.asarray(weights), dtype)
     if fw is None and aw is None:
         w = None

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -263,9 +263,17 @@ def broadcast_shapes(  # numpydoc ignore=PR01,RT01
     return tuple(out)
 
 
-def cov(m: Array, /, *, xp: ArrayNamespace) -> Array:  # numpydoc ignore=PR01,RT01
+def cov(
+    m: Array,
+    /,
+    *,
+    correction: int | float = 1,
+    frequency_weights: Array | None = None,
+    weights: Array | None = None,
+    xp: ArrayNamespace,
+) -> Array:  # numpydoc ignore=PR01,RT01
     """See docstring in array_api_extra._delegation."""
-    m = xp.asarray(m, copy=True)
+    m = xp.asarray(m)
     dtype = (
         xp.float64 if xp.isdtype(m.dtype, "integral") else xp.result_type(m, xp.float64)
     )
@@ -273,21 +281,49 @@ def cov(m: Array, /, *, xp: ArrayNamespace) -> Array:  # numpydoc ignore=PR01,RT
     m = atleast_nd(m, ndim=2, xp=xp)
     m = xp.astype(m, dtype)
 
-    avg = xp.mean(m, axis=-1, keepdims=True)
+    device = _compat.device(m)
+    fw = (
+        None
+        if frequency_weights is None
+        else xp.astype(xp.asarray(frequency_weights, device=device), dtype)
+    )
+    aw = (
+        None
+        if weights is None
+        else xp.astype(xp.asarray(weights, device=device), dtype)
+    )
+    if fw is None and aw is None:
+        w = None
+    elif fw is None:
+        w = aw
+    elif aw is None:
+        w = fw
+    else:
+        w = fw * aw
 
     m_shape = eager_shape(m)
-    fact = m_shape[-1] - 1
+    if w is None:
+        avg = xp.mean(m, axis=-1, keepdims=True)
+        fact = m_shape[-1] - correction
+        if fact <= 0:
+            warnings.warn(
+                "Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2
+            )
+            fact = 0
+    else:
+        v1 = xp.sum(w, axis=-1)
+        avg = xp.sum(m * w, axis=-1, keepdims=True) / v1
+        if aw is None:
+            fact = v1 - correction
+        else:
+            fact = v1 - correction * xp.sum(w * aw, axis=-1) / v1
 
-    if fact <= 0:
-        warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning, stacklevel=2)
-        fact = 0
-
-    m -= avg
-    m_transpose = xp.matrix_transpose(m)
-    if xp.isdtype(m_transpose.dtype, "complex floating"):
-        m_transpose = xp.conj(m_transpose)
-    c = xp.matmul(m, m_transpose)
-    c /= fact
+    m_c = m - avg
+    m_w = m_c if w is None else m_c * w
+    m_cT = xp.matrix_transpose(m_c)
+    if xp.isdtype(m_cT.dtype, "complex floating"):
+        m_cT = xp.conj(m_cT)
+    c = xp.matmul(m_w, m_cT) / fact
     axes = tuple(axis for axis, length in enumerate(c.shape) if length == 1)
     return xp.squeeze(c, axis=axes)
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -665,7 +665,7 @@ class TestCov:
         m = rng.random((3, 10))
         fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
         ref = np.cov(m, fweights=fw)
-        res = cov(xp.asarray(m), frequency_weights=xp.asarray(fw))
+        res = cov(xp.asarray(m), fweights=xp.asarray(fw))
         xp_assert_close(res, xp.asarray(ref))
 
     def test_weights(self, xp: ModuleType):
@@ -673,7 +673,7 @@ class TestCov:
         m = rng.random((3, 10))
         aw = rng.random(10)
         ref = np.cov(m, aweights=aw)
-        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        res = cov(xp.asarray(m), aweights=xp.asarray(aw))
         xp_assert_close(res, xp.asarray(ref))
 
     def test_both_weights(self, xp: ModuleType):
@@ -686,8 +686,8 @@ class TestCov:
             res = cov(
                 xp.asarray(m),
                 correction=correction,
-                frequency_weights=xp.asarray(fw),
-                weights=xp.asarray(aw),
+                fweights=xp.asarray(fw),
+                aweights=xp.asarray(aw),
             )
             xp_assert_close(res, xp.asarray(ref))
 
@@ -697,7 +697,7 @@ class TestCov:
         n_var, n_obs = 3, 15
         m = rng.random((*batch_shape, n_var, n_obs))
         aw = rng.random(n_obs)
-        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        res = cov(xp.asarray(m), aweights=xp.asarray(aw))
         ref_list = [np.cov(m_, aweights=aw) for m_ in np.reshape(m, (-1, n_var, n_obs))]
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
         xp_assert_close(res, xp.asarray(ref))
@@ -713,8 +713,8 @@ class TestCov:
         res = cov(
             xp.asarray(m),
             axis=-2,
-            frequency_weights=xp.asarray(fw),
-            weights=xp.asarray(aw),
+            fweights=xp.asarray(fw),
+            aweights=xp.asarray(aw),
         )
         xp_assert_close(res, xp.asarray(ref))
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -608,6 +608,30 @@ class TestCov:
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
         xp_assert_close(res, xp.asarray(ref))
 
+    @pytest.mark.parametrize("bias", [True, False, 0, 1])
+    def test_bias(self, xp: ModuleType, bias: bool):
+        # `bias` maps to `correction`: bias=True -> correction=0, bias=False -> 1.
+        x = np.array([-2.1, -1, 4.3])
+        y = np.array([3, 1.1, 0.12])
+        X = np.stack((x, y), axis=0)
+        ref = np.cov(X, bias=bias)
+        xp_assert_close(
+            cov(xp.asarray(X, dtype=xp.float64), correction=0 if bias else 1),
+            xp.asarray(ref, dtype=xp.float64),
+            rtol=1e-6,
+        )
+
+    @pytest.mark.parametrize("bias", [True, False, 0, 1])
+    def test_bias_batch(self, xp: ModuleType, bias: bool):
+        rng = np.random.default_rng(8847643423)
+        batch_shape = (3, 4)
+        n_var, n_obs = 3, 20
+        m = rng.random((*batch_shape, n_var, n_obs))
+        res = cov(xp.asarray(m), correction=0 if bias else 1)
+        ref_list = [np.cov(m_, bias=bias) for m_ in np.reshape(m, (-1, n_var, n_obs))]
+        ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
+        xp_assert_close(res, xp.asarray(ref))
+
     def test_correction(self, xp: ModuleType):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 20))

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -608,6 +608,97 @@ class TestCov:
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
         xp_assert_close(res, xp.asarray(ref))
 
+    def test_correction(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 20))
+        for correction in (0, 1, 2):
+            ref = np.cov(m, ddof=correction)
+            res = cov(xp.asarray(m), correction=correction)
+            xp_assert_close(res, xp.asarray(ref))
+
+    def test_correction_float(self, xp: ModuleType):
+        # Float correction: reference computed by hand (numpy.cov rejects
+        # non-integer ddof; our generic path supports it).
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 20))
+        n = m.shape[-1]
+        centered = m - m.mean(axis=-1, keepdims=True)
+        ref = centered @ centered.T / (n - 1.5)
+        res = cov(xp.asarray(m), correction=1.5)
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_axis(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((20, 3))  # observations on axis 0
+        ref = np.cov(m, rowvar=False)
+        res = cov(xp.asarray(m), axis=0)
+        xp_assert_close(res, xp.asarray(ref))
+        res_neg = cov(xp.asarray(m), axis=-2)
+        xp_assert_close(res_neg, xp.asarray(ref))
+
+    def test_frequency_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 10))
+        fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
+        ref = np.cov(m, fweights=fw)
+        res = cov(xp.asarray(m), frequency_weights=xp.asarray(fw))
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 10))
+        aw = rng.random(10)
+        ref = np.cov(m, aweights=aw)
+        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_both_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 10))
+        fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
+        aw = rng.random(10)
+        for correction in (0, 1, 2):
+            ref = np.cov(m, ddof=correction, fweights=fw, aweights=aw)
+            res = cov(
+                xp.asarray(m),
+                correction=correction,
+                frequency_weights=xp.asarray(fw),
+                weights=xp.asarray(aw),
+            )
+            xp_assert_close(res, xp.asarray(ref))
+
+    def test_batch_with_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        batch_shape = (2, 3)
+        n_var, n_obs = 3, 15
+        m = rng.random((*batch_shape, n_var, n_obs))
+        aw = rng.random(n_obs)
+        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        ref_list = [np.cov(m_, aweights=aw) for m_ in np.reshape(m, (-1, n_var, n_obs))]
+        ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_axis_with_weights(self, xp: ModuleType):
+        # axis=-2 (observations on first of 2D) combined with weights:
+        # verifies that moveaxis and weight alignment cooperate.
+        rng = np.random.default_rng(20260417)
+        m = rng.random((15, 3))  # observations on axis 0
+        aw = rng.random(15)
+        fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1, 1, 1, 2, 1, 1], dtype=np.int64)
+        ref = np.cov(m, rowvar=False, fweights=fw, aweights=aw)
+        res = cov(
+            xp.asarray(m),
+            axis=-2,
+            frequency_weights=xp.asarray(fw),
+            weights=xp.asarray(aw),
+        )
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_axis_out_of_bounds(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        with pytest.raises(IndexError):
+            _ = cov(m, axis=5)
+
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)
 class TestOneHot:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -723,6 +723,19 @@ class TestCov:
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
+    def test_weights_shape_validation(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        # Wrong length.
+        with pytest.raises(ValueError, match="`fweights` has length"):
+            _ = cov(m, fweights=xp.asarray([1, 2]))
+        with pytest.raises(ValueError, match="`aweights` has length"):
+            _ = cov(m, aweights=xp.asarray([0.1, 0.2]))
+        # Wrong ndim.
+        with pytest.raises(ValueError, match="`fweights` must be 1-D"):
+            _ = cov(m, fweights=xp.asarray([[1, 2, 3]]))
+        with pytest.raises(ValueError, match="`aweights` must be 1-D"):
+            _ = cov(m, aweights=xp.asarray([[0.1, 0.2, 0.3]]))
+
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)
 class TestOneHot:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -723,18 +723,6 @@ class TestCov:
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
-    def test_weights_shape_validation(self, xp: ModuleType):
-        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        # Wrong length.
-        with pytest.raises(ValueError, match="`fweights` has length"):
-            _ = cov(m, fweights=xp.asarray([1, 2]))
-        with pytest.raises(ValueError, match="`aweights` has length"):
-            _ = cov(m, aweights=xp.asarray([0.1, 0.2]))
-        # Wrong ndim.
-        with pytest.raises(ValueError, match="`fweights` must be 1-D"):
-            _ = cov(m, fweights=xp.asarray([[1, 2, 3]]))
-        with pytest.raises(ValueError, match="`aweights` must be 1-D"):
-            _ = cov(m, aweights=xp.asarray([[0.1, 0.2, 0.3]]))
 
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -732,7 +732,7 @@ class TestCov:
         m = rng.random((3, 10))
         fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
         ref = np.cov(m, fweights=fw)
-        res = cov(xp.asarray(m), frequency_weights=xp.asarray(fw))
+        res = cov(xp.asarray(m), fweights=xp.asarray(fw))
         xp_assert_close(res, xp.asarray(ref))
 
     def test_weights(self, xp: ModuleType):
@@ -740,7 +740,7 @@ class TestCov:
         m = rng.random((3, 10))
         aw = rng.random(10)
         ref = np.cov(m, aweights=aw)
-        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        res = cov(xp.asarray(m), aweights=xp.asarray(aw))
         xp_assert_close(res, xp.asarray(ref))
 
     def test_both_weights(self, xp: ModuleType):
@@ -753,8 +753,8 @@ class TestCov:
             res = cov(
                 xp.asarray(m),
                 correction=correction,
-                frequency_weights=xp.asarray(fw),
-                weights=xp.asarray(aw),
+                fweights=xp.asarray(fw),
+                aweights=xp.asarray(aw),
             )
             xp_assert_close(res, xp.asarray(ref))
 
@@ -764,7 +764,7 @@ class TestCov:
         n_var, n_obs = 3, 15
         m = rng.random((*batch_shape, n_var, n_obs))
         aw = rng.random(n_obs)
-        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        res = cov(xp.asarray(m), aweights=xp.asarray(aw))
         ref_list = [np.cov(m_, aweights=aw) for m_ in np.reshape(m, (-1, n_var, n_obs))]
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
         xp_assert_close(res, xp.asarray(ref))
@@ -780,8 +780,8 @@ class TestCov:
         res = cov(
             xp.asarray(m),
             axis=-2,
-            frequency_weights=xp.asarray(fw),
-            weights=xp.asarray(aw),
+            fweights=xp.asarray(fw),
+            aweights=xp.asarray(aw),
         )
         xp_assert_close(res, xp.asarray(ref))
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -675,6 +675,97 @@ class TestCov:
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
         assert_close(res, xp.asarray(ref))
 
+    def test_correction(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 20))
+        for correction in (0, 1, 2):
+            ref = np.cov(m, ddof=correction)
+            res = cov(xp.asarray(m), correction=correction)
+            xp_assert_close(res, xp.asarray(ref))
+
+    def test_correction_float(self, xp: ModuleType):
+        # Float correction: reference computed by hand (numpy.cov rejects
+        # non-integer ddof; our generic path supports it).
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 20))
+        n = m.shape[-1]
+        centered = m - m.mean(axis=-1, keepdims=True)
+        ref = centered @ centered.T / (n - 1.5)
+        res = cov(xp.asarray(m), correction=1.5)
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_axis(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((20, 3))  # observations on axis 0
+        ref = np.cov(m, rowvar=False)
+        res = cov(xp.asarray(m), axis=0)
+        xp_assert_close(res, xp.asarray(ref))
+        res_neg = cov(xp.asarray(m), axis=-2)
+        xp_assert_close(res_neg, xp.asarray(ref))
+
+    def test_frequency_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 10))
+        fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
+        ref = np.cov(m, fweights=fw)
+        res = cov(xp.asarray(m), frequency_weights=xp.asarray(fw))
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 10))
+        aw = rng.random(10)
+        ref = np.cov(m, aweights=aw)
+        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_both_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 10))
+        fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
+        aw = rng.random(10)
+        for correction in (0, 1, 2):
+            ref = np.cov(m, ddof=correction, fweights=fw, aweights=aw)
+            res = cov(
+                xp.asarray(m),
+                correction=correction,
+                frequency_weights=xp.asarray(fw),
+                weights=xp.asarray(aw),
+            )
+            xp_assert_close(res, xp.asarray(ref))
+
+    def test_batch_with_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        batch_shape = (2, 3)
+        n_var, n_obs = 3, 15
+        m = rng.random((*batch_shape, n_var, n_obs))
+        aw = rng.random(n_obs)
+        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        ref_list = [np.cov(m_, aweights=aw) for m_ in np.reshape(m, (-1, n_var, n_obs))]
+        ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_axis_with_weights(self, xp: ModuleType):
+        # axis=-2 (observations on first of 2D) combined with weights:
+        # verifies that moveaxis and weight alignment cooperate.
+        rng = np.random.default_rng(20260417)
+        m = rng.random((15, 3))  # observations on axis 0
+        aw = rng.random(15)
+        fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1, 1, 1, 2, 1, 1], dtype=np.int64)
+        ref = np.cov(m, rowvar=False, fweights=fw, aweights=aw)
+        res = cov(
+            xp.asarray(m),
+            axis=-2,
+            frequency_weights=xp.asarray(fw),
+            weights=xp.asarray(aw),
+        )
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_axis_out_of_bounds(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        with pytest.raises(IndexError):
+            _ = cov(m, axis=5)
+
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)
 class TestOneHot:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -783,18 +783,6 @@ class TestCov:
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
-    def test_weights_shape_validation(self, xp: ModuleType):
-        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        # Wrong length.
-        with pytest.raises(ValueError, match="`fweights` has length"):
-            _ = cov(m, fweights=xp.asarray([1, 2]))
-        with pytest.raises(ValueError, match="`aweights` has length"):
-            _ = cov(m, aweights=xp.asarray([0.1, 0.2]))
-        # Wrong ndim.
-        with pytest.raises(ValueError, match="`fweights` must be 1-D"):
-            _ = cov(m, fweights=xp.asarray([[1, 2, 3]]))
-        with pytest.raises(ValueError, match="`aweights` must be 1-D"):
-            _ = cov(m, aweights=xp.asarray([[0.1, 0.2, 0.3]]))
 
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -801,6 +801,22 @@ class TestCov:
         with pytest.raises((ValueError, RuntimeError)):
             _ = cov(m, correction=0.5, aweights=w_bad)
 
+    def test_torch_autograd(self, torch: ModuleType):
+        # The batched (generic) path must not detach gradients or mutate the
+        # input tensor in place, as `xp.asarray` does on torch.
+        xp = torch
+        rng = np.random.default_rng(20260417)
+        m = xp.asarray(rng.random((4, 3, 20)), dtype=xp.float64)
+        m.requires_grad_(True)
+        # cov returns the array-api `Array` type; at runtime it is a torch
+        # tensor, so cast to access autograd attributes without type errors.
+        c = cast(Any, cov(m))  # batched -> generic path
+        assert c.requires_grad
+        assert m.requires_grad  # input tensor not mutated
+        c.sum().backward()
+        assert m.grad is not None
+        assert bool(xp.all(xp.isfinite(m.grad)))
+
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)
 class TestOneHot:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -617,6 +617,27 @@ class TestCov:
         expect = xp.asarray([[1.0, -1.0j], [1.0j, 1.0]], dtype=xp.complex128)
         assert_close(actual, expect)
 
+    def test_complex_with_weights(self, xp: ArrayNamespace):
+        m = np.asarray(
+            [[1 + 1j, 2 + 2j, 4 + 1j], [3 - 1j, 5 + 2j, 7 + 0j]],
+            dtype=np.complex128,
+        )
+        weights = np.asarray([1.0, 2.0, 1.0])
+        correction = 0.5  # Force the generic implementation.
+
+        weight_sum = weights.sum()
+        avg = (m * weights).sum(axis=-1, keepdims=True) / weight_sum
+        centered = m - avg
+        normalizer = weight_sum - correction * (weights**2).sum() / weight_sum
+        expected = (centered * weights) @ centered.conj().T / normalizer
+
+        actual = cov(
+            xp.asarray(m),
+            correction=correction,
+            aweights=xp.asarray(weights),
+        )
+        assert_close(actual, xp.asarray(expected))
+
     def test_empty(self, xp: ArrayNamespace):
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always", RuntimeWarning)
@@ -669,20 +690,20 @@ class TestCov:
         assert_close(res, xp.asarray(ref))
 
     @pytest.mark.parametrize("bias", [True, False, 0, 1])
-    def test_bias(self, xp: ModuleType, bias: bool):
+    def test_bias(self, xp: ArrayNamespace, bias: bool):
         # `bias` maps to `correction`: bias=True -> correction=0, bias=False -> 1.
         x = np.array([-2.1, -1, 4.3])
         y = np.array([3, 1.1, 0.12])
         X = np.stack((x, y), axis=0)
         ref = np.cov(X, bias=bias)
-        xp_assert_close(
+        assert_close(
             cov(xp.asarray(X, dtype=xp.float64), correction=0 if bias else 1),
             xp.asarray(ref, dtype=xp.float64),
             rtol=1e-6,
         )
 
     @pytest.mark.parametrize("bias", [True, False, 0, 1])
-    def test_bias_batch(self, xp: ModuleType, bias: bool):
+    def test_bias_batch(self, xp: ArrayNamespace, bias: bool):
         rng = np.random.default_rng(8847643423)
         batch_shape = (3, 4)
         n_var, n_obs = 3, 20
@@ -690,17 +711,17 @@ class TestCov:
         res = cov(xp.asarray(m), correction=0 if bias else 1)
         ref_list = [np.cov(m_, bias=bias) for m_ in np.reshape(m, (-1, n_var, n_obs))]
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_correction(self, xp: ModuleType):
+    def test_correction(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 20))
         for correction in (0, 1, 2):
             ref = np.cov(m, ddof=correction)
             res = cov(xp.asarray(m), correction=correction)
-            xp_assert_close(res, xp.asarray(ref))
+            assert_close(res, xp.asarray(ref))
 
-    def test_correction_float(self, xp: ModuleType):
+    def test_correction_float(self, xp: ArrayNamespace):
         # Float correction: reference computed by hand (numpy.cov rejects
         # non-integer ddof; our generic path supports it).
         rng = np.random.default_rng(20260417)
@@ -709,34 +730,34 @@ class TestCov:
         centered = m - m.mean(axis=-1, keepdims=True)
         ref = centered @ centered.T / (n - 1.5)
         res = cov(xp.asarray(m), correction=1.5)
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_axis(self, xp: ModuleType):
+    def test_axis(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((20, 3))  # observations on axis 0
         ref = np.cov(m, rowvar=False)
         res = cov(xp.asarray(m), axis=0)
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
         res_neg = cov(xp.asarray(m), axis=-2)
-        xp_assert_close(res_neg, xp.asarray(ref))
+        assert_close(res_neg, xp.asarray(ref))
 
-    def test_frequency_weights(self, xp: ModuleType):
+    def test_frequency_weights(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 10))
         fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
         ref = np.cov(m, fweights=fw)
         res = cov(xp.asarray(m), fweights=xp.asarray(fw))
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_weights(self, xp: ModuleType):
+    def test_weights(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 10))
         aw = rng.random(10)
         ref = np.cov(m, aweights=aw)
         res = cov(xp.asarray(m), aweights=xp.asarray(aw))
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_both_weights(self, xp: ModuleType):
+    def test_both_weights(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 10))
         fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
@@ -749,9 +770,9 @@ class TestCov:
                 fweights=xp.asarray(fw),
                 aweights=xp.asarray(aw),
             )
-            xp_assert_close(res, xp.asarray(ref))
+            assert_close(res, xp.asarray(ref))
 
-    def test_batch_with_weights(self, xp: ModuleType):
+    def test_batch_with_weights(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         batch_shape = (2, 3)
         n_var, n_obs = 3, 15
@@ -760,9 +781,9 @@ class TestCov:
         res = cov(xp.asarray(m), aweights=xp.asarray(aw))
         ref_list = [np.cov(m_, aweights=aw) for m_ in np.reshape(m, (-1, n_var, n_obs))]
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_axis_with_weights(self, xp: ModuleType):
+    def test_axis_with_weights(self, xp: ArrayNamespace):
         # axis=-2 (observations on first of 2D) combined with weights:
         # verifies that moveaxis and weight alignment cooperate.
         rng = np.random.default_rng(20260417)
@@ -776,14 +797,14 @@ class TestCov:
             fweights=xp.asarray(fw),
             aweights=xp.asarray(aw),
         )
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_axis_out_of_bounds(self, xp: ModuleType):
+    def test_axis_out_of_bounds(self, xp: ArrayNamespace):
         m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
-    def test_weights_wrong_ndim(self, xp: ModuleType):
+    def test_weights_wrong_ndim(self, xp: ArrayNamespace):
         m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         w2d = xp.asarray([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
         # Non-integer correction forces the generic path where the
@@ -793,7 +814,7 @@ class TestCov:
         with pytest.raises((ValueError, TypeError)):
             _ = cov(m, correction=0.5, aweights=w2d)
 
-    def test_weights_wrong_length(self, xp: ModuleType):
+    def test_weights_wrong_length(self, xp: ArrayNamespace):
         m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         w_bad = xp.asarray([1.0, 1.0])  # expected length 3
         with pytest.raises((ValueError, RuntimeError)):
@@ -801,18 +822,49 @@ class TestCov:
         with pytest.raises((ValueError, RuntimeError)):
             _ = cov(m, correction=0.5, aweights=w_bad)
 
-    def test_torch_autograd(self, torch: ModuleType):
+    def test_weights_unknown_length(self, da: ArrayNamespace):
+        m_np = np.asarray([[1.0, 2.0, 3.0], [4.0, 6.0, 8.0]])
+        weights_np = np.asarray([1.0, 2.0, 3.0])
+        keep_np = np.asarray([True, False, True])
+
+        keep = da.asarray(keep_np)
+        m = da.asarray(m_np)[:, keep]
+        weights = da.asarray(weights_np)[keep]
+        assert math.isnan(m.shape[-1])
+        assert math.isnan(weights.shape[0])
+
+        actual = cov(m, aweights=weights)
+        desired = np.cov(m_np[:, keep_np], aweights=weights_np[keep_np])
+        assert_close(actual, da.asarray(desired))
+
+    def test_weights_dof_warning_eager(self):
+        xp = array_namespace(cast(Array, np.empty(0)))
+        m = xp.asarray([[1.0, 2.0], [3.0, 4.0]])
+        weights = xp.asarray([1.0, 1.0])
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = cov(m, correction=2.5, aweights=weights)
+        assert any(
+            isinstance(warning.message, RuntimeWarning)
+            and "Degrees of freedom <= 0" in str(warning.message)
+            for warning in caught
+        )
+
+    def test_torch_autograd(self, torch: ArrayNamespace):
         # The batched (generic) path must not detach gradients or mutate the
         # input tensor in place, as `xp.asarray` does on torch.
         xp = torch
         rng = np.random.default_rng(20260417)
         m = xp.asarray(rng.random((4, 3, 20)), dtype=xp.float64)
         m.requires_grad_(True)
+        m_before = m.detach().clone()
         # cov returns the array-api `Array` type; at runtime it is a torch
         # tensor, so cast to access autograd attributes without type errors.
         c = cast(Any, cov(m))  # batched -> generic path
         assert c.requires_grad
         assert m.requires_grad  # input tensor not mutated
+        assert_equal(m.detach(), m_before)
         c.sum().backward()
         assert m.grad is not None
         assert bool(xp.all(xp.isfinite(m.grad)))

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -783,6 +783,19 @@ class TestCov:
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
+    def test_weights_shape_validation(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        # Wrong length.
+        with pytest.raises(ValueError, match="`fweights` has length"):
+            _ = cov(m, fweights=xp.asarray([1, 2]))
+        with pytest.raises(ValueError, match="`aweights` has length"):
+            _ = cov(m, aweights=xp.asarray([0.1, 0.2]))
+        # Wrong ndim.
+        with pytest.raises(ValueError, match="`fweights` must be 1-D"):
+            _ = cov(m, fweights=xp.asarray([[1, 2, 3]]))
+        with pytest.raises(ValueError, match="`aweights` must be 1-D"):
+            _ = cov(m, aweights=xp.asarray([[0.1, 0.2, 0.3]]))
+
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)
 class TestOneHot:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -845,7 +845,7 @@ class TestCov:
         assert_close(actual, da.asarray(desired))
 
     def test_weights_dof_warning_eager(self):
-        xp = array_namespace(cast(Array, np.empty(0)))
+        xp = array_namespace(cast(Array, cast(object, np.empty(0))))
         m = xp.asarray([[1.0, 2.0], [3.0, 4.0]])
         weights = xp.asarray([1.0, 1.0])
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -783,6 +783,23 @@ class TestCov:
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
+    def test_weights_wrong_ndim(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        w2d = xp.asarray([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
+        # Non-integer correction forces the generic path where the
+        # validation lives; native backends raise for the same reason.
+        with pytest.raises((ValueError, TypeError)):
+            _ = cov(m, correction=0.5, fweights=w2d)
+        with pytest.raises((ValueError, TypeError)):
+            _ = cov(m, correction=0.5, aweights=w2d)
+
+    def test_weights_wrong_length(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        w_bad = xp.asarray([1.0, 1.0])  # expected length 3
+        with pytest.raises((ValueError, RuntimeError)):
+            _ = cov(m, correction=0.5, fweights=w_bad)
+        with pytest.raises((ValueError, RuntimeError)):
+            _ = cov(m, correction=0.5, aweights=w_bad)
 
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -725,7 +725,7 @@ class TestCov:
         m = rng.random((3, 10))
         fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
         ref = np.cov(m, fweights=fw)
-        res = cov(xp.asarray(m), frequency_weights=xp.asarray(fw))
+        res = cov(xp.asarray(m), fweights=xp.asarray(fw))
         xp_assert_close(res, xp.asarray(ref))
 
     def test_weights(self, xp: ModuleType):
@@ -733,7 +733,7 @@ class TestCov:
         m = rng.random((3, 10))
         aw = rng.random(10)
         ref = np.cov(m, aweights=aw)
-        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        res = cov(xp.asarray(m), aweights=xp.asarray(aw))
         xp_assert_close(res, xp.asarray(ref))
 
     def test_both_weights(self, xp: ModuleType):
@@ -746,8 +746,8 @@ class TestCov:
             res = cov(
                 xp.asarray(m),
                 correction=correction,
-                frequency_weights=xp.asarray(fw),
-                weights=xp.asarray(aw),
+                fweights=xp.asarray(fw),
+                aweights=xp.asarray(aw),
             )
             xp_assert_close(res, xp.asarray(ref))
 
@@ -757,7 +757,7 @@ class TestCov:
         n_var, n_obs = 3, 15
         m = rng.random((*batch_shape, n_var, n_obs))
         aw = rng.random(n_obs)
-        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        res = cov(xp.asarray(m), aweights=xp.asarray(aw))
         ref_list = [np.cov(m_, aweights=aw) for m_ in np.reshape(m, (-1, n_var, n_obs))]
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
         xp_assert_close(res, xp.asarray(ref))
@@ -773,8 +773,8 @@ class TestCov:
         res = cov(
             xp.asarray(m),
             axis=-2,
-            frequency_weights=xp.asarray(fw),
-            weights=xp.asarray(aw),
+            fweights=xp.asarray(fw),
+            aweights=xp.asarray(aw),
         )
         xp_assert_close(res, xp.asarray(ref))
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -838,7 +838,7 @@ class TestCov:
         assert_close(actual, da.asarray(desired))
 
     def test_weights_dof_warning_eager(self):
-        xp = array_namespace(cast(Array, np.empty(0)))
+        xp = array_namespace(cast(Array, cast(object, np.empty(0))))
         m = xp.asarray([[1.0, 2.0], [3.0, 4.0]])
         weights = xp.asarray([1.0, 1.0])
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -808,6 +808,22 @@ class TestCov:
         with pytest.raises((ValueError, RuntimeError)):
             _ = cov(m, correction=0.5, aweights=w_bad)
 
+    def test_torch_autograd(self, torch: ModuleType):
+        # The batched (generic) path must not detach gradients or mutate the
+        # input tensor in place, as `xp.asarray` does on torch.
+        xp = torch
+        rng = np.random.default_rng(20260417)
+        m = xp.asarray(rng.random((4, 3, 20)), dtype=xp.float64)
+        m.requires_grad_(True)
+        # cov returns the array-api `Array` type; at runtime it is a torch
+        # tensor, so cast to access autograd attributes without type errors.
+        c = cast(Any, cov(m))  # batched -> generic path
+        assert c.requires_grad
+        assert m.requires_grad  # input tensor not mutated
+        c.sum().backward()
+        assert m.grad is not None
+        assert bool(xp.all(xp.isfinite(m.grad)))
+
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)
 class TestOneHot:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -668,6 +668,97 @@ class TestCov:
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
         assert_close(res, xp.asarray(ref))
 
+    def test_correction(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 20))
+        for correction in (0, 1, 2):
+            ref = np.cov(m, ddof=correction)
+            res = cov(xp.asarray(m), correction=correction)
+            xp_assert_close(res, xp.asarray(ref))
+
+    def test_correction_float(self, xp: ModuleType):
+        # Float correction: reference computed by hand (numpy.cov rejects
+        # non-integer ddof; our generic path supports it).
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 20))
+        n = m.shape[-1]
+        centered = m - m.mean(axis=-1, keepdims=True)
+        ref = centered @ centered.T / (n - 1.5)
+        res = cov(xp.asarray(m), correction=1.5)
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_axis(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((20, 3))  # observations on axis 0
+        ref = np.cov(m, rowvar=False)
+        res = cov(xp.asarray(m), axis=0)
+        xp_assert_close(res, xp.asarray(ref))
+        res_neg = cov(xp.asarray(m), axis=-2)
+        xp_assert_close(res_neg, xp.asarray(ref))
+
+    def test_frequency_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 10))
+        fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
+        ref = np.cov(m, fweights=fw)
+        res = cov(xp.asarray(m), frequency_weights=xp.asarray(fw))
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 10))
+        aw = rng.random(10)
+        ref = np.cov(m, aweights=aw)
+        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_both_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        m = rng.random((3, 10))
+        fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
+        aw = rng.random(10)
+        for correction in (0, 1, 2):
+            ref = np.cov(m, ddof=correction, fweights=fw, aweights=aw)
+            res = cov(
+                xp.asarray(m),
+                correction=correction,
+                frequency_weights=xp.asarray(fw),
+                weights=xp.asarray(aw),
+            )
+            xp_assert_close(res, xp.asarray(ref))
+
+    def test_batch_with_weights(self, xp: ModuleType):
+        rng = np.random.default_rng(20260417)
+        batch_shape = (2, 3)
+        n_var, n_obs = 3, 15
+        m = rng.random((*batch_shape, n_var, n_obs))
+        aw = rng.random(n_obs)
+        res = cov(xp.asarray(m), weights=xp.asarray(aw))
+        ref_list = [np.cov(m_, aweights=aw) for m_ in np.reshape(m, (-1, n_var, n_obs))]
+        ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_axis_with_weights(self, xp: ModuleType):
+        # axis=-2 (observations on first of 2D) combined with weights:
+        # verifies that moveaxis and weight alignment cooperate.
+        rng = np.random.default_rng(20260417)
+        m = rng.random((15, 3))  # observations on axis 0
+        aw = rng.random(15)
+        fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1, 1, 1, 2, 1, 1], dtype=np.int64)
+        ref = np.cov(m, rowvar=False, fweights=fw, aweights=aw)
+        res = cov(
+            xp.asarray(m),
+            axis=-2,
+            frequency_weights=xp.asarray(fw),
+            weights=xp.asarray(aw),
+        )
+        xp_assert_close(res, xp.asarray(ref))
+
+    def test_axis_out_of_bounds(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        with pytest.raises(IndexError):
+            _ = cov(m, axis=5)
+
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)
 class TestOneHot:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -790,6 +790,19 @@ class TestCov:
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
+    def test_weights_shape_validation(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        # Wrong length.
+        with pytest.raises(ValueError, match="`fweights` has length"):
+            _ = cov(m, fweights=xp.asarray([1, 2]))
+        with pytest.raises(ValueError, match="`aweights` has length"):
+            _ = cov(m, aweights=xp.asarray([0.1, 0.2]))
+        # Wrong ndim.
+        with pytest.raises(ValueError, match="`fweights` must be 1-D"):
+            _ = cov(m, fweights=xp.asarray([[1, 2, 3]]))
+        with pytest.raises(ValueError, match="`aweights` must be 1-D"):
+            _ = cov(m, aweights=xp.asarray([[0.1, 0.2, 0.3]]))
+
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)
 class TestOneHot:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -675,6 +675,30 @@ class TestCov:
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
         assert_close(res, xp.asarray(ref))
 
+    @pytest.mark.parametrize("bias", [True, False, 0, 1])
+    def test_bias(self, xp: ModuleType, bias: bool):
+        # `bias` maps to `correction`: bias=True -> correction=0, bias=False -> 1.
+        x = np.array([-2.1, -1, 4.3])
+        y = np.array([3, 1.1, 0.12])
+        X = np.stack((x, y), axis=0)
+        ref = np.cov(X, bias=bias)
+        xp_assert_close(
+            cov(xp.asarray(X, dtype=xp.float64), correction=0 if bias else 1),
+            xp.asarray(ref, dtype=xp.float64),
+            rtol=1e-6,
+        )
+
+    @pytest.mark.parametrize("bias", [True, False, 0, 1])
+    def test_bias_batch(self, xp: ModuleType, bias: bool):
+        rng = np.random.default_rng(8847643423)
+        batch_shape = (3, 4)
+        n_var, n_obs = 3, 20
+        m = rng.random((*batch_shape, n_var, n_obs))
+        res = cov(xp.asarray(m), correction=0 if bias else 1)
+        ref_list = [np.cov(m_, bias=bias) for m_ in np.reshape(m, (-1, n_var, n_obs))]
+        ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
+        xp_assert_close(res, xp.asarray(ref))
+
     def test_correction(self, xp: ModuleType):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 20))

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -668,6 +668,30 @@ class TestCov:
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
         assert_close(res, xp.asarray(ref))
 
+    @pytest.mark.parametrize("bias", [True, False, 0, 1])
+    def test_bias(self, xp: ModuleType, bias: bool):
+        # `bias` maps to `correction`: bias=True -> correction=0, bias=False -> 1.
+        x = np.array([-2.1, -1, 4.3])
+        y = np.array([3, 1.1, 0.12])
+        X = np.stack((x, y), axis=0)
+        ref = np.cov(X, bias=bias)
+        xp_assert_close(
+            cov(xp.asarray(X, dtype=xp.float64), correction=0 if bias else 1),
+            xp.asarray(ref, dtype=xp.float64),
+            rtol=1e-6,
+        )
+
+    @pytest.mark.parametrize("bias", [True, False, 0, 1])
+    def test_bias_batch(self, xp: ModuleType, bias: bool):
+        rng = np.random.default_rng(8847643423)
+        batch_shape = (3, 4)
+        n_var, n_obs = 3, 20
+        m = rng.random((*batch_shape, n_var, n_obs))
+        res = cov(xp.asarray(m), correction=0 if bias else 1)
+        ref_list = [np.cov(m_, bias=bias) for m_ in np.reshape(m, (-1, n_var, n_obs))]
+        ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
+        xp_assert_close(res, xp.asarray(ref))
+
     def test_correction(self, xp: ModuleType):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 20))

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -790,18 +790,6 @@ class TestCov:
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
-    def test_weights_shape_validation(self, xp: ModuleType):
-        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        # Wrong length.
-        with pytest.raises(ValueError, match="`fweights` has length"):
-            _ = cov(m, fweights=xp.asarray([1, 2]))
-        with pytest.raises(ValueError, match="`aweights` has length"):
-            _ = cov(m, aweights=xp.asarray([0.1, 0.2]))
-        # Wrong ndim.
-        with pytest.raises(ValueError, match="`fweights` must be 1-D"):
-            _ = cov(m, fweights=xp.asarray([[1, 2, 3]]))
-        with pytest.raises(ValueError, match="`aweights` must be 1-D"):
-            _ = cov(m, aweights=xp.asarray([[0.1, 0.2, 0.3]]))
 
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -624,6 +624,27 @@ class TestCov:
         expect = xp.asarray([[1.0, -1.0j], [1.0j, 1.0]], dtype=xp.complex128)
         assert_close(actual, expect)
 
+    def test_complex_with_weights(self, xp: ArrayNamespace):
+        m = np.asarray(
+            [[1 + 1j, 2 + 2j, 4 + 1j], [3 - 1j, 5 + 2j, 7 + 0j]],
+            dtype=np.complex128,
+        )
+        weights = np.asarray([1.0, 2.0, 1.0])
+        correction = 0.5  # Force the generic implementation.
+
+        weight_sum = weights.sum()
+        avg = (m * weights).sum(axis=-1, keepdims=True) / weight_sum
+        centered = m - avg
+        normalizer = weight_sum - correction * (weights**2).sum() / weight_sum
+        expected = (centered * weights) @ centered.conj().T / normalizer
+
+        actual = cov(
+            xp.asarray(m),
+            correction=correction,
+            aweights=xp.asarray(weights),
+        )
+        assert_close(actual, xp.asarray(expected))
+
     def test_empty(self, xp: ArrayNamespace):
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always", RuntimeWarning)
@@ -676,20 +697,20 @@ class TestCov:
         assert_close(res, xp.asarray(ref))
 
     @pytest.mark.parametrize("bias", [True, False, 0, 1])
-    def test_bias(self, xp: ModuleType, bias: bool):
+    def test_bias(self, xp: ArrayNamespace, bias: bool):
         # `bias` maps to `correction`: bias=True -> correction=0, bias=False -> 1.
         x = np.array([-2.1, -1, 4.3])
         y = np.array([3, 1.1, 0.12])
         X = np.stack((x, y), axis=0)
         ref = np.cov(X, bias=bias)
-        xp_assert_close(
+        assert_close(
             cov(xp.asarray(X, dtype=xp.float64), correction=0 if bias else 1),
             xp.asarray(ref, dtype=xp.float64),
             rtol=1e-6,
         )
 
     @pytest.mark.parametrize("bias", [True, False, 0, 1])
-    def test_bias_batch(self, xp: ModuleType, bias: bool):
+    def test_bias_batch(self, xp: ArrayNamespace, bias: bool):
         rng = np.random.default_rng(8847643423)
         batch_shape = (3, 4)
         n_var, n_obs = 3, 20
@@ -697,17 +718,17 @@ class TestCov:
         res = cov(xp.asarray(m), correction=0 if bias else 1)
         ref_list = [np.cov(m_, bias=bias) for m_ in np.reshape(m, (-1, n_var, n_obs))]
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_correction(self, xp: ModuleType):
+    def test_correction(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 20))
         for correction in (0, 1, 2):
             ref = np.cov(m, ddof=correction)
             res = cov(xp.asarray(m), correction=correction)
-            xp_assert_close(res, xp.asarray(ref))
+            assert_close(res, xp.asarray(ref))
 
-    def test_correction_float(self, xp: ModuleType):
+    def test_correction_float(self, xp: ArrayNamespace):
         # Float correction: reference computed by hand (numpy.cov rejects
         # non-integer ddof; our generic path supports it).
         rng = np.random.default_rng(20260417)
@@ -716,34 +737,34 @@ class TestCov:
         centered = m - m.mean(axis=-1, keepdims=True)
         ref = centered @ centered.T / (n - 1.5)
         res = cov(xp.asarray(m), correction=1.5)
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_axis(self, xp: ModuleType):
+    def test_axis(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((20, 3))  # observations on axis 0
         ref = np.cov(m, rowvar=False)
         res = cov(xp.asarray(m), axis=0)
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
         res_neg = cov(xp.asarray(m), axis=-2)
-        xp_assert_close(res_neg, xp.asarray(ref))
+        assert_close(res_neg, xp.asarray(ref))
 
-    def test_frequency_weights(self, xp: ModuleType):
+    def test_frequency_weights(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 10))
         fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
         ref = np.cov(m, fweights=fw)
         res = cov(xp.asarray(m), fweights=xp.asarray(fw))
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_weights(self, xp: ModuleType):
+    def test_weights(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 10))
         aw = rng.random(10)
         ref = np.cov(m, aweights=aw)
         res = cov(xp.asarray(m), aweights=xp.asarray(aw))
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_both_weights(self, xp: ModuleType):
+    def test_both_weights(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         m = rng.random((3, 10))
         fw = np.asarray([1, 2, 1, 3, 1, 2, 1, 1, 2, 1], dtype=np.int64)
@@ -756,9 +777,9 @@ class TestCov:
                 fweights=xp.asarray(fw),
                 aweights=xp.asarray(aw),
             )
-            xp_assert_close(res, xp.asarray(ref))
+            assert_close(res, xp.asarray(ref))
 
-    def test_batch_with_weights(self, xp: ModuleType):
+    def test_batch_with_weights(self, xp: ArrayNamespace):
         rng = np.random.default_rng(20260417)
         batch_shape = (2, 3)
         n_var, n_obs = 3, 15
@@ -767,9 +788,9 @@ class TestCov:
         res = cov(xp.asarray(m), aweights=xp.asarray(aw))
         ref_list = [np.cov(m_, aweights=aw) for m_ in np.reshape(m, (-1, n_var, n_obs))]
         ref = np.reshape(np.stack(ref_list), (*batch_shape, n_var, n_var))
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_axis_with_weights(self, xp: ModuleType):
+    def test_axis_with_weights(self, xp: ArrayNamespace):
         # axis=-2 (observations on first of 2D) combined with weights:
         # verifies that moveaxis and weight alignment cooperate.
         rng = np.random.default_rng(20260417)
@@ -783,14 +804,14 @@ class TestCov:
             fweights=xp.asarray(fw),
             aweights=xp.asarray(aw),
         )
-        xp_assert_close(res, xp.asarray(ref))
+        assert_close(res, xp.asarray(ref))
 
-    def test_axis_out_of_bounds(self, xp: ModuleType):
+    def test_axis_out_of_bounds(self, xp: ArrayNamespace):
         m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
-    def test_weights_wrong_ndim(self, xp: ModuleType):
+    def test_weights_wrong_ndim(self, xp: ArrayNamespace):
         m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         w2d = xp.asarray([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
         # Non-integer correction forces the generic path where the
@@ -800,7 +821,7 @@ class TestCov:
         with pytest.raises((ValueError, TypeError)):
             _ = cov(m, correction=0.5, aweights=w2d)
 
-    def test_weights_wrong_length(self, xp: ModuleType):
+    def test_weights_wrong_length(self, xp: ArrayNamespace):
         m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         w_bad = xp.asarray([1.0, 1.0])  # expected length 3
         with pytest.raises((ValueError, RuntimeError)):
@@ -808,18 +829,49 @@ class TestCov:
         with pytest.raises((ValueError, RuntimeError)):
             _ = cov(m, correction=0.5, aweights=w_bad)
 
-    def test_torch_autograd(self, torch: ModuleType):
+    def test_weights_unknown_length(self, da: ArrayNamespace):
+        m_np = np.asarray([[1.0, 2.0, 3.0], [4.0, 6.0, 8.0]])
+        weights_np = np.asarray([1.0, 2.0, 3.0])
+        keep_np = np.asarray([True, False, True])
+
+        keep = da.asarray(keep_np)
+        m = da.asarray(m_np)[:, keep]
+        weights = da.asarray(weights_np)[keep]
+        assert math.isnan(m.shape[-1])
+        assert math.isnan(weights.shape[0])
+
+        actual = cov(m, aweights=weights)
+        desired = np.cov(m_np[:, keep_np], aweights=weights_np[keep_np])
+        assert_close(actual, da.asarray(desired))
+
+    def test_weights_dof_warning_eager(self):
+        xp = array_namespace(cast(Array, np.empty(0)))
+        m = xp.asarray([[1.0, 2.0], [3.0, 4.0]])
+        weights = xp.asarray([1.0, 1.0])
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = cov(m, correction=2.5, aweights=weights)
+        assert any(
+            isinstance(warning.message, RuntimeWarning)
+            and "Degrees of freedom <= 0" in str(warning.message)
+            for warning in caught
+        )
+
+    def test_torch_autograd(self, torch: ArrayNamespace):
         # The batched (generic) path must not detach gradients or mutate the
         # input tensor in place, as `xp.asarray` does on torch.
         xp = torch
         rng = np.random.default_rng(20260417)
         m = xp.asarray(rng.random((4, 3, 20)), dtype=xp.float64)
         m.requires_grad_(True)
+        m_before = m.detach().clone()
         # cov returns the array-api `Array` type; at runtime it is a torch
         # tensor, so cast to access autograd attributes without type errors.
         c = cast(Any, cov(m))  # batched -> generic path
         assert c.requires_grad
         assert m.requires_grad  # input tensor not mutated
+        assert_equal(m.detach(), m_before)
         c.sum().backward()
         assert m.grad is not None
         assert bool(xp.all(xp.isfinite(m.grad)))

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -790,6 +790,23 @@ class TestCov:
         with pytest.raises(IndexError):
             _ = cov(m, axis=5)
 
+    def test_weights_wrong_ndim(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        w2d = xp.asarray([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
+        # Non-integer correction forces the generic path where the
+        # validation lives; native backends raise for the same reason.
+        with pytest.raises((ValueError, TypeError)):
+            _ = cov(m, correction=0.5, fweights=w2d)
+        with pytest.raises((ValueError, TypeError)):
+            _ = cov(m, correction=0.5, aweights=w2d)
+
+    def test_weights_wrong_length(self, xp: ModuleType):
+        m = xp.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        w_bad = xp.asarray([1.0, 1.0])  # expected length 3
+        with pytest.raises((ValueError, RuntimeError)):
+            _ = cov(m, correction=0.5, fweights=w_bad)
+        with pytest.raises((ValueError, RuntimeError)):
+            _ = cov(m, correction=0.5, aweights=w_bad)
 
 
 @pytest.mark.xfail_xp_backend(Backend.SPARSE, reason="no arange", strict=False)


### PR DESCRIPTION
Resolves #688.

## Summary

- Adds `axis`, `correction`, `frequency_weights`, and `weights` parameters to `xpx.cov`, unlocking the degrees-of-freedom and weighted variants that `numpy.cov` and `torch.cov` already support.
- Naming follows array-api conventions (`axis`, `correction`) used elsewhere in this library rather than numpy's (`rowvar`, `bias`, `ddof`). The docstring includes a one-to-one mapping for users migrating from `numpy.cov`.

## Design

The delegation moves observations to the last axis via `xp.moveaxis`, which collapses `rowvar` out of backend dispatch entirely — only `ddof` (numpy/cupy/dask/jax) vs `correction` (torch) differs between branches.

Fallbacks to the generic implementation (`_funcs.cov`):
- `m.ndim > 2` (batched input, not supported by any native).
- Non-integer `correction` (rejected by `numpy.cov`'s `ddof`).
- Dask with weights — `dask.array.cov` forces `.compute()` on a lazy 0-D scalar via its internal `if fact <= 0` check. The generic path stays fully lazy because its weighted branch doesn't compare `fact` to zero (noted in docstring).

Weighted formula in `_funcs.cov` matches numpy's (algebraically): `c = (m_c · w) @ m_c.T / (v1 - correction · v2 / v1)`.

## Tests

New `TestCov` cases validate against `np.cov` as reference:
- `test_correction` (integer ddof)
- `test_correction_float` (generic-path-only, hand-computed reference)
- `test_axis` / `test_axis_with_weights` / `test_axis_out_of_bounds`
- `test_frequency_weights` / `test_weights` / `test_both_weights`
- `test_batch_with_weights`

## Test plan
- [x] `pytest tests/test_funcs.py::TestCov` — 126 passed across numpy, torch, jax, dask, array-api-strict
- [x] `pytest tests/test_funcs.py` full — 4263 passed, 0 failed
- [x] `lefthook run pre-commit` — ruff, numpydoc, mypy, pyright, typos all green
- [x] Dask laziness verified — `lazy_xp_function(cov)` asserts 0 `.compute()` calls, holds for weighted path via the fallback