### PR TITLE
DEV: add `writeable` to ignored typos

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -6,3 +6,4 @@ ignore-hidden = false
 nd = "nd"
 typ = "typ"
 cardinalis = "cardinalis"
+writeable = "writeable"


### PR DESCRIPTION
this one is inherited from NumPy
