### PR TITLE
ENH: testing: special case 0D-arrays for `check_shape=False`

### DIFF
--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -81,7 +81,7 @@ def _check_ns_shape_dtype(
         # Ignore shape, but check flattened size. This is normally done by
         # np.testing.assert_array_equal etc even when strict=False, but not for
         # non-materializable arrays.
-        # This check excludes 0d arrays as they are special case in numpy.
+        # This check excludes 0d arrays as they are special-cased in NumPy.
         actual_size = math.prod(actual_shape)  # pyright: ignore[reportUnknownArgumentType]
         desired_size = math.prod(desired_shape)  # pyright: ignore[reportUnknownArgumentType]
         msg = f"sizes do not match: {actual_size} != f{desired_size}"

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -77,10 +77,11 @@ def _check_ns_shape_dtype(
     if check_shape:
         msg = f"shapes do not match: {actual_shape} != f{desired_shape}"
         assert actual_shape == desired_shape, msg
-    else:
+    elif desired.ndim > 0:
         # Ignore shape, but check flattened size. This is normally done by
         # np.testing.assert_array_equal etc even when strict=False, but not for
         # non-materializable arrays.
+        # This check excludes 0d arrays as they are special case in numpy.
         actual_size = math.prod(actual_shape)  # pyright: ignore[reportUnknownArgumentType]
         desired_size = math.prod(desired_shape)  # pyright: ignore[reportUnknownArgumentType]
         msg = f"sizes do not match: {actual_size} != f{desired_size}"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please check out the contributor guidance at https://data-apis.org/array-api-extra/contributing.html.
-->
Discussed in #724 

Fixing `check_shape`'s else condition to take into account 0d arrays. They are special case in numpy. [See](https://numpy.org/devdocs/reference/generated/numpy.testing.assert_array_equal.html#numpy-testing-assert-array-equal)