### PR TITLE
ENH: testing: support 0-D arrays for `rtol` and `atol`

### DIFF
--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -288,16 +288,12 @@ def xp_assert_close(
             rtol = 1e-7
 
     if hasattr(atol, "ndim"):
-        atol = as_numpy_array(atol, xp=xp)
-        if atol.ndim > 0:
-            msg = "atol must be a scalar or 0-D array"
-            raise TypeError(msg)
+        if atol.ndim == 0:
+            atol = as_numpy_array(atol, xp=xp)
 
     if hasattr(rtol, "ndim"):
-        rtol = as_numpy_array(rtol, xp=xp)
-        if rtol.ndim > 0:
-            msg = "rtol must be a scalar or 0-D array"
-            raise TypeError(msg)
+        if rtol.ndim == 0:
+            rtol = as_numpy_array(rtol, xp=xp)
 
     actual_np = as_numpy_array(actual, xp=xp)
     desired_np = as_numpy_array(desired, xp=xp)

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -228,8 +228,8 @@ def xp_assert_close(
     actual: Array,
     desired: Array,
     *,
-    rtol: float | None = None,
-    atol: float = 0,
+    rtol: float | Array | None = None,
+    atol: float | Array = 0,
     equal_nan: bool = True,
     err_msg: str = "",
     verbose: bool = True,
@@ -246,9 +246,9 @@ def xp_assert_close(
         The array produced by the tested function.
     desired : Array
         The expected array (typically hardcoded).
-    rtol : float, optional
+    rtol : float or Array, optional
         Relative tolerance. Default: dtype-dependent.
-    atol : float, optional
+    atol : float or Array, optional
         Absolute tolerance. Default: 0.
     equal_nan : bool, default: True
         Whether to consider NaNs in corresponding locations as equal.
@@ -286,6 +286,18 @@ def xp_assert_close(
             rtol = xp.finfo(actual.dtype).eps ** 0.5 * 4
         else:
             rtol = 1e-7
+
+    if not isinstance(atol, float):
+        atol = as_numpy_array(atol, xp=xp)
+        if atol.ndim > 0:
+            msg = "atol must be a scalar or 0-D array"
+            raise TypeError(msg)
+
+    if not isinstance(rtol, float):
+        rtol = as_numpy_array(rtol, xp=xp)
+        if rtol.ndim > 0:
+            msg = "rtol must be a scalar or 0-D array"
+            raise TypeError(msg)
 
     actual_np = as_numpy_array(actual, xp=xp)
     desired_np = as_numpy_array(desired, xp=xp)

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -287,13 +287,13 @@ def xp_assert_close(
         else:
             rtol = 1e-7
 
-    if not isinstance(atol, float):
+    if hasattr(atol, "ndim"):
         atol = as_numpy_array(atol, xp=xp)
         if atol.ndim > 0:
             msg = "atol must be a scalar or 0-D array"
             raise TypeError(msg)
 
-    if not isinstance(rtol, float):
+    if hasattr(rtol, "ndim"):
         rtol = as_numpy_array(rtol, xp=xp)
         if rtol.ndim > 0:
             msg = "rtol must be a scalar or 0-D array"

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -287,21 +287,20 @@ def xp_assert_close(
         else:
             rtol = 1e-7
 
-    if hasattr(atol, "ndim"):
-        if atol.ndim == 0:
-            atol = as_numpy_array(atol, xp=xp)
+    if hasattr(atol, "ndim") and atol.ndim == 0:  # pyright: ignore[reportAttributeAccessIssue]
+        atol = cast(Array, as_numpy_array(cast(Array, atol), xp=xp))  # pyright: ignore[reportInvalidCast]
 
-    if hasattr(rtol, "ndim"):
-        if rtol.ndim == 0:
-            rtol = as_numpy_array(rtol, xp=xp)
+    if hasattr(rtol, "ndim") and rtol.ndim == 0:  # pyright: ignore[reportAttributeAccessIssue,reportOptionalMemberAccess]
+        rtol = cast(Array, as_numpy_array(cast(Array, rtol), xp=xp))  # pyright: ignore[reportInvalidCast]
 
     actual_np = as_numpy_array(actual, xp=xp)
     desired_np = as_numpy_array(desired, xp=xp)
-    np.testing.assert_allclose(  # pyright: ignore[reportCallIssue]
+    np.testing.assert_allclose(  # pyright: ignore[reportCallIssue]  # pyrefly: ignore[no-matching-overload]
         actual_np,
         desired_np,
-        rtol=rtol,  # pyright: ignore[reportArgumentType]
-        atol=atol,
+        # https://github.com/numpy/numpy/issues/31449
+        rtol=rtol,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        atol=atol,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
         equal_nan=equal_nan,
         err_msg=err_msg,
         verbose=verbose,

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -298,7 +298,6 @@ def xp_assert_close(
     np.testing.assert_allclose(  # pyright: ignore[reportCallIssue]
         actual_np,
         desired_np,
-        # https://github.com/numpy/numpy/issues/31449
         rtol=rtol,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
         atol=atol,
         equal_nan=equal_nan,

--- a/src/array_api_extra/_lib/_testing.py
+++ b/src/array_api_extra/_lib/_testing.py
@@ -271,6 +271,8 @@ def xp_assert_close(
     Notes
     -----
     The default `atol` and `rtol` differ from `xp.all(xpx.isclose(a, b))`.
+
+    Array arguments to `atol` and `rtol` must be valid input to :py:func:`float`.
     """
     actual, desired, xp = _check_ns_shape_dtype(
         actual, desired, check_dtype, check_shape, check_scalar
@@ -286,21 +288,19 @@ def xp_assert_close(
             rtol = xp.finfo(actual.dtype).eps ** 0.5 * 4
         else:
             rtol = 1e-7
+    else:
+        rtol = float(rtol)
 
-    if hasattr(atol, "ndim") and atol.ndim == 0:  # pyright: ignore[reportAttributeAccessIssue]
-        atol = cast(Array, as_numpy_array(cast(Array, atol), xp=xp))  # pyright: ignore[reportInvalidCast]
-
-    if hasattr(rtol, "ndim") and rtol.ndim == 0:  # pyright: ignore[reportAttributeAccessIssue,reportOptionalMemberAccess]
-        rtol = cast(Array, as_numpy_array(cast(Array, rtol), xp=xp))  # pyright: ignore[reportInvalidCast]
+    atol = float(atol)
 
     actual_np = as_numpy_array(actual, xp=xp)
     desired_np = as_numpy_array(desired, xp=xp)
-    np.testing.assert_allclose(  # pyright: ignore[reportCallIssue]  # pyrefly: ignore[no-matching-overload]
+    np.testing.assert_allclose(  # pyright: ignore[reportCallIssue]
         actual_np,
         desired_np,
         # https://github.com/numpy/numpy/issues/31449
         rtol=rtol,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-        atol=atol,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        atol=atol,
         equal_nan=equal_nan,
         err_msg=err_msg,
         verbose=verbose,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please check out the contributor guidance at https://data-apis.org/array-api-extra/contributing.html.
-->

As discussed here: https://github.com/scipy/scipy/pull/25143#issuecomment-4468111548