### PR TITLE
ENH: testing: hiding assertion internals in pytest traceback  

### DIFF
--- a/src/array_api_extra/testing.py
+++ b/src/array_api_extra/testing.py
@@ -770,6 +770,7 @@ def assert_close(
 
     Array arguments to `atol` and `rtol` must be valid input to :class:`float`.
     """
+    __tracebackhide__ = True
     actual, desired, xp, np = _check_ns_shape_dtype(
         actual, desired, check_dtype, check_shape, check_scalar, xp
     )
@@ -850,6 +851,7 @@ def assert_equal(
     assert_close : Similar function for inexact equality checks.
     numpy.testing.assert_array_equal : Similar function for NumPy arrays.
     """
+    __tracebackhide__ = True
     actual, desired, xp, np = _check_ns_shape_dtype(
         actual, desired, check_dtype, check_shape, check_scalar, xp
     )
@@ -908,6 +910,7 @@ def assert_less(
     assert_close : Similar function for inexact equality checks.
     numpy.testing.assert_array_less : Similar function for NumPy arrays.
     """
+    __tracebackhide__ = True
     x, y, xp, np = _check_ns_shape_dtype(
         x, y, check_dtype, check_shape, check_scalar, xp
     )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please check out the contributor guidance at https://data-apis.org/array-api-extra/contributing.html.
-->
Fixes #780 