### PR TITLE
DEP/TST/DOC: adjustments for v2025.12 of the standard

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,8 +62,8 @@ a specific version, or vendor the library inside your own.
 
 ```{note}
 This library depends on `array-api-compat`. We aim for compatibility with
-the latest released version of array-api-compat, and your mileage may vary
-with older or dev versions.
+the latest released versions of the standard and array-api-compat,
+and your mileage may vary with older or dev/draft versions.
 ```
 
 (vendoring)=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,8 @@ reportUnusedParameter = false
 reportImportCycles = false
 # PyRight can't trace types in lambdas
 reportUnknownLambdaType = false
+# conflicts with https://docs.astral.sh/ruff/rules/explicit-string-concatenation/
+reportImplicitStringConcatenation = false
 
 executionEnvironments = [
   { root = "tests", reportPrivateUsage = false, reportUnknownArgumentType = false },

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -15,7 +15,7 @@ from ._lib._utils._compat import (
     is_torch_namespace,
 )
 from ._lib._utils._compat import device as get_device
-from ._lib._utils._helpers import asarrays, eager_shape
+from ._lib._utils._helpers import asarrays, deprecated, eager_shape
 from ._lib._utils._typing import Array, DType
 
 __all__ = [
@@ -83,18 +83,22 @@ def atleast_nd(x: Array, /, *, ndim: int, xp: ModuleType | None = None) -> Array
     return _funcs.atleast_nd(x, ndim=ndim, xp=xp)
 
 
+@deprecated(
+    "`xpx.broadcast_shapes` is deprecated and will be removed in v1.0.0. "
+    "`xp.broadcast_shapes` exists in the standard as of v2025.12."
+)
 def broadcast_shapes(
     *shapes: tuple[float | None, ...], xp: ModuleType | None = None
 ) -> tuple[int | None, ...]:
     """
     Compute the shape of the broadcasted arrays.
 
+    .. deprecated:: 0.11.0
+        :func:`broadcast_shapes` is deprecated and will be removed in v1.0.0.
+        :func:`array_api.broadcast_shapes` exists in the standard as of v2025.12.
+
     Duplicates :func:`numpy.broadcast_shapes`, with additional support for
     None and NaN sizes.
-
-    This is equivalent to ``xp.broadcast_arrays(arr1, arr2, ...)[0].shape``
-    without needing to worry about the backend potentially deep copying
-    the arrays.
 
     Parameters
     ----------
@@ -300,17 +304,24 @@ def create_diagonal(
     return _funcs.create_diagonal(x, offset=offset, xp=xp)
 
 
+@deprecated(
+    "`xpx.expand_dims` is deprecated and will be removed in v1.0.0. "
+    "`xp.expand_dims` with support for a tuple of ints in `axis` "
+    "exists in the standard as of v2025.12."
+)
 def expand_dims(
     a: Array, /, *, axis: int | tuple[int, ...] = (0,), xp: ModuleType | None = None
 ) -> Array:
     """
     Expand the shape of an array.
 
+    .. deprecated:: 0.11.0
+        :func:`expand_dims` is deprecated and will be removed in v1.0.0.
+        :func:`array_api.expand_dims` with support for a tuple of ints in `axis`
+        exists in the standard as of v2025.12.
+
     Insert (a) new axis/axes that will appear at the position(s) specified by
     `axis` in the expanded array shape.
-
-    This is ``xp.expand_dims`` for `axis` an int *or a tuple of ints*.
-    Roughly equivalent to ``numpy.expand_dims`` for NumPy arrays.
 
     Parameters
     ----------
@@ -804,7 +815,7 @@ def searchsorted(
     Find the indices into a sorted array ``x1`` such that if the elements in ``x2``
     were inserted before the indices, the resulting array would remain sorted.
 
-    The behavior of this function is similar to that of `array_api.searchsorted`,
+    The behavior of this function is similar to that of :func:`array_api.searchsorted`,
     but it relaxes the requirement that `x1` must be one-dimensional.
     This function is vectorized, treating slices along the last axis
     as elements and preceding axes as batch (or "loop") dimensions.
@@ -1220,8 +1231,8 @@ def isin(
     """
     Determine whether each element in `a` is present in `b`.
 
-    Return a boolean array of the same shape as `a` that is True for elements
-    that are in `b` and False otherwise.
+    This is :func:`array_api.isin`, with additional `assume_unique`
+    and `kind` parameters.
 
     Parameters
     ----------

--- a/src/array_api_extra/_lib/_utils/_helpers.py
+++ b/src/array_api_extra/_lib/_utils/_helpers.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import functools
 import io
 import math
 import pickle
 import types
+import warnings
 from collections.abc import Callable, Generator, Iterable, Iterator
 from functools import wraps
 from types import ModuleType
@@ -48,6 +50,7 @@ T = TypeVar("T")
 __all__ = [
     "asarrays",
     "capabilities",
+    "deprecated",
     "eager_shape",
     "in1d",
     "is_python_scalar",
@@ -56,6 +59,26 @@ __all__ = [
     "pickle_flatten",
     "pickle_unflatten",
 ]
+
+
+def deprecated(
+    msg: str, stacklevel: int = 2
+) -> Callable[[Callable[P, T]], Callable[P, T]]:  # numpydoc ignore=PR01,RT01
+    """Deprecate a function by emitting a warning on use."""
+
+    def decorate(func: Callable[P, T]) -> Callable[P, T]:  # numpydoc ignore=GL08
+        @functools.wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:  # numpydoc ignore=GL08
+            warnings.warn(
+                msg,
+                category=DeprecationWarning,
+                stacklevel=stacklevel,
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorate
 
 
 def in1d(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,9 @@ def xp(
     # Possibly wrap module with array_api_compat
     xp = array_namespace(xp.empty(0))
 
+    if library.like(Backend.ARRAY_API_STRICT):
+        xp.set_array_api_strict_flags(api_version="2025.12")
+
     if library == Backend.ARRAY_API_STRICTEST:
         with xp.ArrayAPIStrictFlags(
             boolean_indexing=False,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2,6 +2,7 @@ py.install_sources([
     '__init__.py',
     'conftest.py',
     'test_at.py',
+    'test_deprecation.py',
     'test_funcs.py',
     'test_helpers.py',
     'test_lazy.py',

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,15 @@
+from types import ModuleType
+
+import pytest
+
+from array_api_extra import broadcast_shapes, expand_dims
+
+
+class TestDeprecatedFunctions:
+    def test_broadcast_shapes(self, xp: ModuleType):
+        with pytest.raises(DeprecationWarning, match=r"removed in v1.0.0"):
+            _ = broadcast_shapes((2, 3), (2, 1), xp=xp)
+
+    def test_expand_dims(self, xp: ModuleType):
+        with pytest.raises(DeprecationWarning, match=r"removed in v1.0.0"):
+            _ = expand_dims(xp.ones(2), axis=0, xp=xp)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -488,6 +488,7 @@ class TestAtLeastND:
         assert_equal(y, xp.asarray([[[[[[[[[3.0]], [[2.0]]]]]]]]]))
 
 
+@pytest.mark.filterwarnings("ignore:.*removed in v1.0.0.*:DeprecationWarning")
 class TestBroadcastShapes:
     def test_delegates_known_integer_shapes(self, monkeypatch: pytest.MonkeyPatch):
         calls = []
@@ -828,6 +829,7 @@ class TestDefaultDType:
         assert default_dtype(xp, "complex floating") == xp.complex64
 
 
+@pytest.mark.filterwarnings(r"ignore:.*removed in v1.0.0.*:DeprecationWarning")
 class TestExpandDims:
     def test_single_axis(self, xp: ModuleType):
         """Trivial case where xpx.expand_dims doesn't add anything to xp.expand_dims"""


### PR DESCRIPTION
https://data-apis.org/array-api/draft/changelog.html#v2025-12

- test against array-api-strict with v2025.12
- document that we only promise support for the latest version of the standard
- deprecate `broadcast_shapes` (now exists in the standard) for removal in v1.0.0
- deprecate `expand_dims` (its extra functionality now exists in the standard) for removal in v1.0.0
- document the extra functionality offered by `xpx.isin` over `xp.isin`
- no adjustments for `xpx.searchsorted` — it still provides documented extra functionality
