### PR TITLE
ENH: pad: normalize `pad_width` on the host for torch

### DIFF
--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -796,7 +796,11 @@ def pad(
         # `torch/_numpy`'s implementation (avoids device transfers)
         pad_width_seq = _funcs.normalize_pad_width(pad_width, x.ndim)
         # torch.nn.functional.pad counts dimensions from the last one
-        flat_pad_width = [w for pair in reversed(pad_width_seq) for w in pair]
+        flat_pad_width = [
+            w
+            for pair in reversed(pad_width_seq)
+            for w in pair
+        ]
         return xp.nn.functional.pad(x, tuple(flat_pad_width), value=constant_values)
 
     return _funcs.pad(x, pad_width, constant_values=constant_values, xp=xp)

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -791,12 +791,13 @@ def pad(
     ):
         return xp.pad(x, pad_width, mode, constant_values=constant_values)
 
-    # https://github.com/pytorch/pytorch/blob/cf76c05b4dc629ac989d1fb8e789d4fac04a095a/torch/_numpy/_funcs_impl.py#L2045-L2056
     if is_torch_namespace(xp):
-        pad_width = xp.asarray(pad_width)
-        pad_width = xp.broadcast_to(pad_width, (x.ndim, 2))
-        pad_width = xp.flip(pad_width, axis=(0,)).flatten()
-        return xp.nn.functional.pad(x, tuple(pad_width), value=constant_values)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        # normalize `pad_width` on the host rather than through a tensor as done in
+        # `torch/_numpy`'s implementation (avoids device transfers)
+        pad_width_seq = _funcs.normalize_pad_width(pad_width, x.ndim)
+        # torch.nn.functional.pad counts dimensions from the last one
+        flat_pad_width = [w for pair in reversed(pad_width_seq) for w in pair]
+        return xp.nn.functional.pad(x, tuple(flat_pad_width), value=constant_values)
 
     return _funcs.pad(x, pad_width, constant_values=constant_values, xp=xp)
 

--- a/src/array_api_extra/_delegation.py
+++ b/src/array_api_extra/_delegation.py
@@ -15,7 +15,12 @@ from ._lib._utils._compat import (
     is_torch_namespace,
 )
 from ._lib._utils._compat import device as get_device
-from ._lib._utils._helpers import asarrays, deprecated, eager_shape
+from ._lib._utils._helpers import (
+    asarrays,
+    deprecated,
+    eager_shape,
+    normalize_pad_width,
+)
 from ._lib._utils._typing import Array, DType
 
 __all__ = [
@@ -794,7 +799,7 @@ def pad(
     if is_torch_namespace(xp):
         # normalize `pad_width` on the host rather than through a tensor as done in
         # `torch/_numpy`'s implementation (avoids device transfers)
-        pad_width_seq = _funcs.normalize_pad_width(pad_width, x.ndim)
+        pad_width_seq = normalize_pad_width(pad_width, x.ndim)
         # torch.nn.functional.pad counts dimensions from the last one
         flat_pad_width = [
             w

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -19,6 +19,7 @@ from ._utils._helpers import (
     eager_shape,
     meta_namespace,
     ndindex,
+    normalize_pad_width,
 )
 from ._utils._typing import Array, Device, DType
 
@@ -536,22 +537,6 @@ def nunique(x: Array, /, *, xp: ModuleType | None = None) -> Array:
         xp.astype(xp.any(~mask), default_int),
         xp.sum(xp.astype(mask, default_int)),
     )
-
-
-def normalize_pad_width(
-    pad_width: int | tuple[int, int] | Sequence[tuple[int, int]],
-    ndim: int,
-) -> list[tuple[int, int]]:  # numpydoc ignore=PR01,RT01
-    """Normalize `pad_width` to a list of `ndim` (before, after) pairs of ints."""
-    if isinstance(pad_width, int):
-        return [(pad_width, pad_width)] * ndim
-    if (
-        isinstance(pad_width, tuple)
-        and len(pad_width) == 2
-        and all(isinstance(i, int) for i in pad_width)
-    ):
-        return [cast(tuple[int, int], pad_width)] * ndim
-    return cast(list[tuple[int, int]], list(pad_width))
 
 
 def pad(

--- a/src/array_api_extra/_lib/_funcs.py
+++ b/src/array_api_extra/_lib/_funcs.py
@@ -538,6 +538,22 @@ def nunique(x: Array, /, *, xp: ModuleType | None = None) -> Array:
     )
 
 
+def normalize_pad_width(
+    pad_width: int | tuple[int, int] | Sequence[tuple[int, int]],
+    ndim: int,
+) -> list[tuple[int, int]]:  # numpydoc ignore=PR01,RT01
+    """Normalize `pad_width` to a list of `ndim` (before, after) pairs of ints."""
+    if isinstance(pad_width, int):
+        return [(pad_width, pad_width)] * ndim
+    if (
+        isinstance(pad_width, tuple)
+        and len(pad_width) == 2
+        and all(isinstance(i, int) for i in pad_width)
+    ):
+        return [cast(tuple[int, int], pad_width)] * ndim
+    return cast(list[tuple[int, int]], list(pad_width))
+
+
 def pad(
     x: Array,
     pad_width: int | tuple[int, int] | Sequence[tuple[int, int]],
@@ -546,17 +562,7 @@ def pad(
     xp: ModuleType,
 ) -> Array:  # numpydoc ignore=PR01,RT01
     """See docstring in `array_api_extra._delegation.py`."""
-    # make pad_width a list of length-2 tuples of ints
-    if isinstance(pad_width, int):
-        pad_width_seq = [(pad_width, pad_width)] * x.ndim
-    elif (
-        isinstance(pad_width, tuple)
-        and len(pad_width) == 2
-        and all(isinstance(i, int) for i in pad_width)
-    ):
-        pad_width_seq = [cast(tuple[int, int], pad_width)] * x.ndim
-    else:
-        pad_width_seq = cast(list[tuple[int, int]], list(pad_width))
+    pad_width_seq = normalize_pad_width(pad_width, x.ndim)
 
     slices: list[slice] = []
     newshape: list[int] = []

--- a/src/array_api_extra/_lib/_utils/_helpers.py
+++ b/src/array_api_extra/_lib/_utils/_helpers.py
@@ -18,6 +18,7 @@ from typing import (
     Generic,
     Literal,
     ParamSpec,
+    Sequence,
     TypeAlias,
     TypeVar,
     cast,
@@ -54,6 +55,7 @@ __all__ = [
     "eager_shape",
     "in1d",
     "is_python_scalar",
+    "normalize_pad_width",
     "jax_autojit",
     "meta_namespace",
     "pickle_flatten",
@@ -608,3 +610,20 @@ def jax_autojit(
         return inner(wargs).obj
 
     return outer
+
+
+
+def normalize_pad_width(
+    pad_width: int | tuple[int, int] | Sequence[tuple[int, int]],
+    ndim: int,
+) -> list[tuple[int, int]]:  # numpydoc ignore=PR01,RT01
+    """Normalize `pad_width` to a list of `ndim` (before, after) pairs of ints."""
+    if isinstance(pad_width, int):
+        return [(pad_width, pad_width)] * ndim
+    if (
+        isinstance(pad_width, tuple)
+        and len(pad_width) == 2
+        and all(isinstance(i, int) for i in pad_width)
+    ):
+        return [cast(tuple[int, int], pad_width)] * ndim
+    return cast(list[tuple[int, int]], list(pad_width))


### PR DESCRIPTION
`pad_width` is host metadata (an int or (before, after) pairs), but the torch delegation branch normalized it by round-tripping through a tensor: `xp.asarray(pad_width)` places it on the *default* device, and the `tuple(...)` call to build the python ints that `torch.nn.functional.pad` expects then performs one device-to-host transfer per element. With a CUDA default device that is a needless host-to-device copy plus 2*ndim synchronizing `.item()` reads per call; with a data-free `meta` default device it raises outright.

Factor the pure-python normalization out of `_funcs.pad` into `normalize_pad_width` and reuse it in the torch branch, reversing the axis order on the host.

This also aligns the torch branch with the documented `pad_width` types (the tensor broadcast incidentally accepted undocumented forms such as shape ``(n, 1)``).

Found this when working on non-default device handling issues in `scipy`; SciPy tests will cover this so I won't worry about introducing multi-device testing here right now.

AI Generation Disclosure: patch generated with Claude Fable 5 (had to tweak both code comments and commit message a bit, but the hard work was done by Claude here).