### PR TITLE
DOC: simplify installation instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,8 +41,6 @@ It is currently used by:
 
 ```shell
 uv add array-api-extra
-# or
-python -m pip install array-api-extra
 ```
 
 And
@@ -50,8 +48,6 @@ And
 
 ```shell
 pixi add array-api-extra
-# or
-mamba install array-api-extra
 ```
 
 ```{warning}


### PR DESCRIPTION
## Summary

- remove the pip and mamba alternatives from the installation examples
- keep uv and pixi as the primary commands while retaining the PyPI and conda-forge links

## Validation

- `git diff HEAD^ HEAD --check`
- exact content checks confirmed that the uv and pixi commands and both package links remain, with only the four intended lines removed
- the full documentation build was not run locally because Pixi is unavailable in this environment

Closes #848.

## Disclosure

This pull request was prepared with AI-assisted automation under explicit human authorization. The scope and local validation limitation are disclosed above.
