### PR TITLE
DEV: use `start` for open-docs on Windows

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -153,7 +153,12 @@ numpy = ">=2.1.3"
 
 [feature.docs.tasks]
 docs = { cmd = "sphinx-build -E -W . build/", cwd = "docs", description = "Build docs", default-environment = "docs" }
+
+[feature.docs.target.unix.tasks]
 open-docs = { cmd = "open build/index.html", cwd = "docs", depends-on = ["docs"], description = "Open the generated docs", default-environment = "docs" }
+
+[feature.docs.target.win.tasks]
+open-docs = { cmd = "cmd /c start build/index.html", cwd = "docs", depends-on = ["docs"], description = "Open the generated docs", default-environment = "docs" }
 
 [feature.dev.dependencies]
 ipython = ">=9.15.0"

--- a/pixi.toml
+++ b/pixi.toml
@@ -153,8 +153,6 @@ numpy = ">=2.1.3"
 
 [feature.docs.tasks]
 docs = { cmd = "sphinx-build -E -W . build/", cwd = "docs", description = "Build docs", default-environment = "docs" }
-
-[feature.docs.target.unix.tasks]
 open-docs = { cmd = "open build/index.html", cwd = "docs", depends-on = ["docs"], description = "Open the generated docs", default-environment = "docs" }
 
 [feature.docs.target.win.tasks]


### PR DESCRIPTION
Closes #839.

Splits the `open-docs` task by platform:

- Unix keeps the existing `open build/index.html` command.
- Windows uses `cmd /c start build/index.html`.

The `cmd /c` wrapper is necessary because Pixi executes tasks with `deno_task_shell`, while `start` is a Windows `cmd.exe` built-in rather than a standalone executable.

Both variants retain the docs dependency, working directory, description, and default environment.

Validation:

- Pixi 0.73 manifest parsing
- Lock file unchanged and up to date
- Full repository lint suite (dprint, Ruff, mypy, Pyright, Pyrefly, typos, actionlint, zizmor, and documentation checks)
- Sphinx docs build with warnings treated as errors
- Unix `open-docs` dry run renders the existing `open build/index.html`

Native Windows execution was not available locally; the Windows target-table selection and command form were verified against Pixi's target-task semantics and Windows `cmd` behavior.
