### PR TITLE
CI: don’t use ubuntu-slim for x64 nogil job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           - {environment: tests-backends, x64_runner: ubuntu-latest}
           - {environment: tests-backends-py311, x64_runner: ubuntu-latest}
           # Non-default pixi task (default: tests-ci)
-          - {environment: tests-nogil, task: "tests --parallel-threads=4", no-coverage: true}
+          - {environment: tests-nogil, task: "tests --parallel-threads=4", no-coverage: true, x64_runner: ubuntu-latest}
           - {environment: tests-run-deps, task: tests-run-deps-cov}
         exclude:
           - {environment: tests-nogil, platform: macos} # data-apis/array-api-extra#900


### PR DESCRIPTION
should speed up our slowest job a little
<!--
Thanks for contributing a pull request!

Please check out the contributor guidance at https://data-apis.org/array-api-extra/contributing.html.
-->
