### PR TITLE
TST: improve xfail message for torch `cov` `test_device`

### DIFF
--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -671,7 +671,9 @@ class TestCov:
         assert_close(cov(x), xp.asarray(11.71, dtype=xp.float64))
         assert_close(cov(y), xp.asarray(2.144133, dtype=xp.float64), rtol=1e-6)
 
-    @pytest.mark.xfail_xp_backend(Backend.TORCH, reason="array-api-extra#455")
+    @pytest.mark.xfail_xp_backend(
+        Backend.TORCH, reason="torch.cov does not support tensors on meta device"
+    )
     def test_device(self, xp: ArrayNamespace, device: Device):
         x = xp.asarray([1, 2, 3], device=device)
         assert get_device(cov(x)) == device


### PR DESCRIPTION
closes gh-455

<!--
Thanks for contributing a pull request!

Please check out the contributor guidance at https://data-apis.org/array-api-extra/contributing.html.
-->
