### PR TITLE
DOC: organise API reference

### DIFF
--- a/docs/api-assorted.md
+++ b/docs/api-assorted.md
@@ -1,5 +1,30 @@
 # Assorted functions
 
+## Creation functions
+
+```{eval-rst}
+.. currentmodule:: array_api_extra
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    create_diagonal
+    one_hot
+```
+
+## Inspection
+
+```{eval-rst}
+.. currentmodule:: array_api_extra
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    default_dtype
+```
+
+## Element-wise functions
+
 ```{eval-rst}
 .. currentmodule:: array_api_extra
 .. autosummary::
@@ -8,33 +33,100 @@
 
     angle
     apply_where
-    argpartition
+    deg2rad
+    isclose
+    nan_to_num
+    rad2deg
+    sinc
+```
+
+## Indexing functions
+
+```{eval-rst}
+.. currentmodule:: array_api_extra
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
     at
+    diag_indices
+    tril_indices
+    triu_indices
+    unravel_index
+```
+
+## Linear algebra functions
+
+```{eval-rst}
+.. currentmodule:: array_api_extra
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    kron
+```
+
+## Manipulation functions
+
+```{eval-rst}
+.. currentmodule:: array_api_extra
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
     atleast_nd
     broadcast_shapes
-    cov
-    create_diagonal
-    default_dtype
-    deg2rad
-    diag_indices
     expand_dims
-    isclose
+    pad
+```
+
+## Searching functions
+
+```{eval-rst}
+.. currentmodule:: array_api_extra
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    searchsorted
+```
+
+## Set functions
+
+```{eval-rst}
+.. currentmodule:: array_api_extra
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
     isin
-    kron
-    nan_to_num
+    nunique
+    setdiff1d
+    union1d
+```
+
+## Sorting functions
+
+```{eval-rst}
+.. currentmodule:: array_api_extra
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    argpartition
+    partition
+```
+
+## Statistical functions
+
+```{eval-rst}
+.. currentmodule:: array_api_extra
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    cov
     nanmax
     nanmin
     nansum
-    nunique
-    one_hot
-    pad
-    partition
-    rad2deg
-    searchsorted
-    setdiff1d
-    sinc
-    tril_indices
-    triu_indices
-    union1d
-    unravel_index
 ```


### PR DESCRIPTION
## Summary

Organises the flat assorted API autosummary into categories aligned with the Python Array API standard, while keeping a single page and preserving the generated reference URLs. All 31 existing public entries remain listed exactly once.

Closes #322.

The open #910 adds `nanmean` to this file. If it lands first, I will rebase and place `nanmean` under Statistical functions.

## Validation

- `pixi run docs` (Sphinx with `-E -W`)
- `pixi run lint`
- coverage check confirming 31 API entries, each listed exactly once

AI assistance: Codex helped analyze the grouping and prepare the change; the resulting diff was verified with the project checks above.