### PR TITLE
DOC: disable overloads section

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,3 +69,4 @@ nitpick_ignore = [
 templates_path = ["_templates"]
 
 always_document_param_types = True
+typehints_document_overloads = False


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please check out the contributor guidance at https://data-apis.org/array-api-extra/contributing.html.
-->

Closes https://github.com/data-apis/array-api-extra/issues/904.

https://data-apis.org/array-api-extra/generated/array_api_extra.apply_where.html
https://data-apis.org/array-api-extra/generated/array_api_extra.lazy_apply.html

had an "overloads" section which this PR removes.

AI disclosure: suggested by Codex and tested/verified locally.