### PR TITLE
MAINT: fix Pixi workspace compat with pixi-build-api-version 7

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -15,6 +15,9 @@ preview = ["pixi-build"]
 requires-pixi = ">=0.73.0"  # for TOML 1.1 support
 exclude-newer = "7d"
 
+[exclude-newer]
+pixi-build-python = "5d"  # for compatibility with pixi-build-api-version 7
+
 ### array-api-extra package definition ###
 
 [package]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please check out the contributor guidance at https://data-apis.org/array-api-extra/contributing.html.
-->

#### Reference issue

<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

<!--Please explain your changes.-->

#### Additional information

<!--Any additional information you think is important.-->

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. -->
