### PR TITLE
TST: skip tests that convert MPArray to NumPy array

### DIFF
--- a/tests/main/test_lazy.py
+++ b/tests/main/test_lazy.py
@@ -108,6 +108,7 @@ def test_lazy_apply_multi_output(xp: ArrayNamespace, as_numpy: bool):
                     Backend.TORCH_GPU, reason="device->host copy"
                 ),
                 pytest.mark.skip_xp_backend(Backend.SPARSE, reason="densification"),
+                pytest.mark.skip_xp_backend(Backend.MPARRAY, reason="precision loss"),
             ],
         ),
     ],
@@ -291,6 +292,7 @@ def test_lazy_apply_none_shape_broadcast(xp: ArrayNamespace):
                     Backend.TORCH_GPU, reason="device->host copy"
                 ),
                 pytest.mark.skip_xp_backend(Backend.SPARSE, reason="densification"),
+                pytest.mark.skip_xp_backend(Backend.MPARRAY, reason="precision loss"),
             ],
         ),
     ],

--- a/tests/main/test_testing.py
+++ b/tests/main/test_testing.py
@@ -452,6 +452,7 @@ class TestLazyXpFunctionClasses:
     @pytest.mark.skip_xp_backend(Backend.CUPY, reason="converts to NumPy")
     @pytest.mark.skip_xp_backend(Backend.JAX_GPU, reason="converts to NumPy")
     @pytest.mark.skip_xp_backend(Backend.TORCH_GPU, reason="converts to NumPy")
+    @pytest.mark.skip_xp_backend(Backend.MPARRAY, reason="precision loss")
     def test_lazy_xp_function_classes(self, xp: ArrayNamespace, library: Backend):
         x = xp.asarray([1.1, 2.2, 3.3])
         y = xp.asarray([1.0, 2.0, 3.0])


### PR DESCRIPTION
#### Reference issue

https://github.com/data-apis/array-api-extra/pull/963/files/2b92ac1821678dbc6317d338937c7f94fc9082bf#diff-c50543e3908e94354bdcf5dc26eca11c2889ac795f4bb43bff052c457994afd1

#### What does this implement/fix?

This skips tests that convert MPArray to NumPy array. They passed before because `np.asarray(my_mparray)` produces an object array with a single element, and simple operations (e.g. arithmetic) will work just fine with this object array because it performs the operations on each element. But I don't think that should be relied on; really, `as_numpy=True` and similar should raise for MPArrays due to precision loss.

#### AI Generation Disclosure

I added `__array__` to MPArray and had GPT-6 run `array-api-extra` tests with this change. We found those three failures and I told it to apply the skips similarly to GPU backends but citing precision loss as the reason.
